### PR TITLE
Add more metadata to pom.xml, according to Sonatype requirements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
 
     <name>SBL - Common Maven configuration</name>
     <description>
-        This is a common root POM for all SBL projects. It defines versions of core plugins,
-        and configuration of code quality metrics, CI server URLs, and distribution management
+        This is a common root POM for many NAV projects. It defines versions of core plugins,
+        configuration of code quality metrics, CI server URLs, and distribution management
         for artifact deploys.
     </description>
     <url>https://github.com/navikt/common-java-modules</url>


### PR DESCRIPTION
Commit message:

>Maven central is strict about requirements for a project before letting
>it be published:
>
>http://central.sonatype.org/pages/requirements.html
>
>This adds the required metadata (name/description/url/license/repo/owners).
>It also sets up a Maven profile "open-source" which overrides distribution
>settings. When we "mvn deploy -Popen-source,release", the project we are
>building will not be deployed to the NAV internal Nexus, but rather
>directly to Maven Central. It will also GPG sign all the artifacts,
>which is a security measure required by Maven Central.

This makes the project ready for release to Maven Central - once the Travis build
is up and running.