### PR TITLE
util: use $PATH as sure-fire environment variable

### DIFF
--- a/util/src/test/java/no/nav/sbl/util/EnvironmentUtilsTest.java
+++ b/util/src/test/java/no/nav/sbl/util/EnvironmentUtilsTest.java
@@ -96,7 +96,7 @@ public class EnvironmentUtilsTest {
 
     @Test
     public void getRequiredProperty_leser_ogsa_other_properties_fra_environment() {
-        String requiredProperty = EnvironmentUtils.getRequiredProperty("SOMETHING_SOMETHING", "JAVA_HOME");
+        String requiredProperty = EnvironmentUtils.getRequiredProperty("SOMETHING_SOMETHING", "PATH");
         assertThat(requiredProperty).isNotBlank();
     }
 


### PR DESCRIPTION
The $JAVA_HOME environment variable might not be set on all
configurations. $PATH is pretty much guaranteed.