### PR TITLE
Remove unnecessary version configuration

### DIFF
--- a/aktor-klient/pom.xml
+++ b/aktor-klient/pom.xml
@@ -10,7 +10,6 @@
 
     <groupId>no.nav.sbl.dialogarena</groupId>
     <artifactId>aktor-klient</artifactId>
-    <version>${project.parent.version}</version>
 
     <properties>
         <nav-fim-aktoer-v2-tjenestespesifikasjon.version>2.0.1</nav-fim-aktoer-v2-tjenestespesifikasjon.version>

--- a/api-app/pom.xml
+++ b/api-app/pom.xml
@@ -10,7 +10,6 @@
         <version>1-SNAPSHOT</version>
     </parent>
     <artifactId>api-app</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/app-mock/pom.xml
+++ b/app-mock/pom.xml
@@ -10,7 +10,6 @@
 
     <groupId>no.nav.sbl.dialogarena</groupId>
     <artifactId>app-mock</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/batch/pom.xml
+++ b/batch/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>common-batch</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -10,7 +10,6 @@
         <version>1-SNAPSHOT</version>
     </parent>
     <artifactId>bom</artifactId>
-    <version>${project.parent.version}</version>
 
     <packaging>pom</packaging>
 

--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -10,7 +10,6 @@
         <version>1-SNAPSHOT</version>
     </parent>
     <artifactId>cache</artifactId>
-    <version>${project.parent.version}</version>
 
     <properties>
         <java.jdk.version>8</java.jdk.version>

--- a/cxf/pom.xml
+++ b/cxf/pom.xml
@@ -10,7 +10,6 @@
 
     <groupId>no.nav.sbl.dialogarena</groupId>
 	<artifactId>common-cxf</artifactId>
-    <version>${project.parent.version}</version>
 
 	<properties>
         <jsoup.version>1.7.2</jsoup.version>

--- a/fasit/pom.xml
+++ b/fasit/pom.xml
@@ -8,7 +8,6 @@
     </parent>
 
     <artifactId>fasit</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/feature-toggle/pom.xml
+++ b/feature-toggle/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>feature-toggle</artifactId>
-    <version>${project.parent.version}</version>
 
     <properties>
         <okhttp.version>3.8.0</okhttp.version>

--- a/feed/pom.xml
+++ b/feed/pom.xml
@@ -12,7 +12,6 @@
 
     <groupId>no.nav.sbl.dialogarena</groupId>
     <artifactId>feed</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>jdbc</artifactId>
-    <version>${project.parent.version}</version>
 
     <properties>
         <vavr.version>0.9.0</vavr.version>

--- a/jetty/pom.xml
+++ b/jetty/pom.xml
@@ -10,7 +10,6 @@
     </parent>
     <groupId>no.nav.sbl.dialogarena</groupId>
     <artifactId>common-jetty</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -10,7 +10,6 @@
         <version>1-SNAPSHOT</version>
     </parent>
     <artifactId>json</artifactId>
-    <version>${project.parent.version}</version>
 
     <properties>
         <java.jdk.version>8</java.jdk.version>

--- a/leaderelection/pom.xml
+++ b/leaderelection/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>common-leaderelection</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/log/pom.xml
+++ b/log/pom.xml
@@ -10,7 +10,6 @@
     </parent>
 
     <artifactId>log</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -10,7 +10,6 @@
 
     <groupId>no.nav</groupId>
     <artifactId>metrics</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/oidc-security/pom.xml
+++ b/oidc-security/pom.xml
@@ -9,7 +9,6 @@
 
     <groupId>no.nav.dialogarena</groupId>
     <artifactId>oidc-security</artifactId>
-    <version>${project.parent.version}</version>
 
     <properties>
         <jose4j.version>0.5.0</jose4j.version>

--- a/pact/pom.xml
+++ b/pact/pom.xml
@@ -11,7 +11,6 @@
     <groupId>no.nav.pact</groupId>
     <artifactId>pact-fo</artifactId>
 
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -9,7 +9,6 @@
     </parent>
 
     <artifactId>rest</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/smoketest/pom.xml
+++ b/smoketest/pom.xml
@@ -9,7 +9,6 @@
 
     <groupId>no.nav.dialogarena</groupId>
     <artifactId>smoketest</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/suspend/pom.xml
+++ b/suspend/pom.xml
@@ -10,7 +10,6 @@
 
     <groupId>no.nav.sbl.dialogarena</groupId>
     <artifactId>common-suspend</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/test-config/pom.xml
+++ b/test-config/pom.xml
@@ -9,7 +9,6 @@
 
     <groupId>no.nav.sbl.dialogarena</groupId>
     <artifactId>test-config</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -9,7 +9,6 @@
 
     <groupId>no.nav.sbl.dialogarena</groupId>
     <artifactId>common-test</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/time/pom.xml
+++ b/time/pom.xml
@@ -9,7 +9,6 @@
 
     <groupId>no.nav.sbl.dialogarena</groupId>
     <artifactId>common-time</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/types/pom.xml
+++ b/types/pom.xml
@@ -9,7 +9,6 @@
 
     <groupId>no.nav.sbl.dialogarena</groupId>
     <artifactId>common-types</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -9,7 +9,6 @@
     </parent>
 
     <artifactId>util</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -9,7 +9,6 @@
 
     <groupId>no.nav.sbl.dialogarena</groupId>
     <artifactId>common-web</artifactId>
-    <version>${project.parent.version}</version>
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
Maven submodules will by default inherit their
parent's version. This change makes it easier
for Maven to resolve dependencies correctly.