### PR TITLE
rest: use mocked HTTP server instead of live data

### DIFF
--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -80,6 +80,12 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>2.16.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/rest/src/test/java/no/nav/sbl/rest/MetricsIntegrationTest.java
+++ b/rest/src/test/java/no/nav/sbl/rest/MetricsIntegrationTest.java
@@ -1,16 +1,25 @@
 package no.nav.sbl.rest;
 
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.net.ServerSocket;
 import java.nio.charset.Charset;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.givenThat;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static java.lang.System.setProperty;
 import static no.nav.metrics.handlers.SensuHandler.SENSU_CLIENT_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MetricsIntegrationTest {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(58089);
 
     @Test
     public void metrikkerSendesTilSensuSocket() throws Exception {
@@ -18,12 +27,11 @@ public class MetricsIntegrationTest {
             sensuServerSocketMock.setSoTimeout(5000);
             setProperty(SENSU_CLIENT_PORT, Integer.toString(sensuServerSocketMock.getLocalPort()));
 
-            RestUtils.withClient(c -> c.target("http://fasit.adeo.no/a/b/c").request().get());
+            givenThat(get(urlEqualTo("/")).willReturn(aResponse().withStatus(200)));
+            RestUtils.withClient(c -> c.target("http://localhost:58089").request().get());
 
             String sensuMetricMessage = IOUtils.toString(sensuServerSocketMock.accept().getInputStream(), Charset.defaultCharset());
             assertThat(sensuMetricMessage).isNotEmpty();
         }
     }
-
-
 }


### PR DESCRIPTION
This commit removes the requirement of having an internal Fasit server
up and running in order to complete the tests.