### PR TITLE
oidc-security: skip tests requiring Fasit when it is unavailable

### DIFF
--- a/oidc-security/src/test/java/no/nav/brukerdialog/security/pingable/IssoSystemBrukerTokenHelsesjekkTest.java
+++ b/oidc-security/src/test/java/no/nav/brukerdialog/security/pingable/IssoSystemBrukerTokenHelsesjekkTest.java
@@ -17,8 +17,10 @@ import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static no.nav.brukerdialog.security.Constants.REFRESH_TIME;
 import static no.nav.dialogarena.config.fasit.FasitUtils.getApplicationEnvironment;
+import static no.nav.sbl.rest.RestUtils.withClient;
 import static no.nav.sbl.util.LogUtils.setGlobalLogLevel;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 
 public class IssoSystemBrukerTokenHelsesjekkTest {
@@ -27,8 +29,22 @@ public class IssoSystemBrukerTokenHelsesjekkTest {
 
     private IssoSystemBrukerTokenHelsesjekk issoSystemBrukerTokenHelsesjekk = new IssoSystemBrukerTokenHelsesjekk();
 
+    private static boolean fasitAlive() {
+        return withClient(client -> {
+            try {
+                int status = client.target("https://fasit.adeo.no").request().get().getStatus();
+                return status == 200;
+            } catch (Exception e) {
+                LOGGER.error("Fasit is unreachable! NOT running integration tests.");
+                LOGGER.error(e.toString());
+                return false;
+            }
+        });
+    }
+
     @BeforeClass
     public static void setup() {
+        assumeTrue(fasitAlive());
         System.getProperties().putAll(getApplicationEnvironment("veilarbaktivitet"));
         setGlobalLogLevel(INFO);
         setProperty(REFRESH_TIME, Integer.toString(MAX_VALUE / 2000)); // slik at hver ping fører til refresh, se SystemUserTokenProvider.tokenIsSoonExpired()


### PR DESCRIPTION
This patch guards IssoSystemBrukerTokenHelsesjekkTest with an an
assumption that the Fasit server can be reached. In turn, this ensures
that tests can be run outside of the NAV test environment.