### PR TITLE
metrics: Marker rapporter med checked exceptions

### DIFF
--- a/metrics/src/main/java/no/nav/metrics/MetodeEvent.java
+++ b/metrics/src/main/java/no/nav/metrics/MetodeEvent.java
@@ -19,9 +19,13 @@ public class MetodeEvent {
 
         try {
             return metodekall.kallMetode();
-        } catch (Throwable throwable) {
+        } catch (RuntimeException | Error unchecked) {
             event.setFailed();
-            throw throwable;
+            throw unchecked;
+        } catch (Throwable checked) {
+            event.setFailed();
+            event.addFieldToReport("checkedException", true);
+            throw checked;
         } finally {
             event.report();
         }

--- a/metrics/src/main/java/no/nav/metrics/MetodeTimer.java
+++ b/metrics/src/main/java/no/nav/metrics/MetodeTimer.java
@@ -8,9 +8,13 @@ public class MetodeTimer {
         try {
             timer.start();
             return metodekall.kallMetode();
-        } catch (Throwable throwable) {
+        } catch (RuntimeException | Error unchecked) {
             timer.setFailed();
-            throw throwable;
+            throw unchecked;
+        } catch (Throwable checked) {
+            timer.setFailed();
+            timer.addFieldToReport("checkedException", true);
+            throw checked;
         } finally {
             timer.stop().report();
         }

--- a/metrics/src/test/java/no/nav/metrics/MetodeEventTest.java
+++ b/metrics/src/test/java/no/nav/metrics/MetodeEventTest.java
@@ -4,6 +4,8 @@ import mockit.Mocked;
 import mockit.Verifications;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -46,6 +48,29 @@ public class MetodeEventTest {
 
         new Verifications() {{
             event.setFailed();
+            event.report();
+        }};
+    }
+
+    @Test
+    public void markererCheckedExceptions(@Mocked final Event event) throws Throwable {
+        Metodekall metodekall = new Metodekall() {
+            @Override
+            public Object kallMetode() throws Throwable {
+                throw new IOException("dummy");
+            }
+        };
+
+        try {
+            MetodeEvent.eventForMetode(metodekall, "eventNavn");
+            fail("skal ha kastet exception");
+        } catch (Exception e) {
+            assertEquals("dummy", e.getMessage());
+        }
+
+        new Verifications() {{
+            event.setFailed();
+            event.addFieldToReport("checkedException", true);
             event.report();
         }};
     }

--- a/metrics/src/test/java/no/nav/metrics/MetodeTimerTest.java
+++ b/metrics/src/test/java/no/nav/metrics/MetodeTimerTest.java
@@ -4,6 +4,8 @@ import mockit.Mocked;
 import mockit.Verifications;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -50,6 +52,32 @@ public class MetodeTimerTest {
         new Verifications() {{
             timer.start();
             timer.setFailed();
+            timer.stop();
+            timer.report();
+        }};
+
+    }
+
+    @Test
+    public void markererCheckedExceptions(@Mocked final Timer timer, @Mocked MetricsFactory factory) throws Throwable {
+        Metodekall metodekall = new Metodekall() {
+            @Override
+            public Object kallMetode() throws Throwable {
+                throw new IOException("dummy");
+            }
+        };
+
+        try {
+            MetodeTimer.timeMetode(metodekall, "timerNavn");
+            fail("Skal kaste exception");
+        } catch (Throwable throwable) {
+            assertEquals("dummy", throwable.getMessage());
+        }
+
+        new Verifications() {{
+            timer.start();
+            timer.setFailed();
+            timer.addFieldToReport("checkedException", true);
             timer.stop();
             timer.report();
         }};


### PR DESCRIPTION
Legger til feltet `checkedException` på rapportene fra MetodeTimer og
MetodeEvent hvis metoden kaster checked exception.

Close #9, OPP-382