### PR TITLE
Generate and propagate correlation ids

### DIFF
--- a/api-app/src/main/java/no/nav/apiapp/logging/MDCFilter.java
+++ b/api-app/src/main/java/no/nav/apiapp/logging/MDCFilter.java
@@ -1,7 +1,7 @@
 package no.nav.apiapp.logging;
 
 import no.nav.apiapp.util.SubjectUtils;
-import no.nav.log.MDCConstants;
+import no.nav.sbl.rest.RestUtils;
 import org.slf4j.MDC;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -12,8 +12,14 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.SecureRandom;
 
+import static no.nav.apiapp.util.StringUtils.of;
+import static no.nav.log.MDCConstants.*;
+import static no.nav.sbl.rest.RestUtils.CORRELATION_ID_HEADER_NAME;
+
 
 public class MDCFilter extends OncePerRequestFilter {
+
+    public static final String CALL_ID_HEADER_NAME = "X-Call-Id";
 
     private static final SecureRandom RANDOM = new SecureRandom();
 
@@ -22,27 +28,41 @@ public class MDCFilter extends OncePerRequestFilter {
         String userId = SubjectUtils.getUserId().orElse("");
         String consumerId = SubjectUtils.getConsumerId().orElse("");
         String callId = generateCallId();
+        String correlationId = of(httpServletRequest.getHeader(CORRELATION_ID_HEADER_NAME)).orElseGet(this::generateCorrelationId);
 
-        MDC.put(MDCConstants.MDC_CALL_ID, callId);
-        MDC.put(MDCConstants.MDC_USER_ID, userId);
-        MDC.put(MDCConstants.MDC_CONSUMER_ID, consumerId);
+        MDC.put(MDC_CALL_ID, callId);
+        MDC.put(MDC_USER_ID, userId);
+        MDC.put(MDC_CONSUMER_ID, consumerId);
+        MDC.put(MDC_CORRELATION_ID, correlationId);
+
+        httpServletResponse.addHeader(CALL_ID_HEADER_NAME, callId);
+        httpServletResponse.addHeader(CORRELATION_ID_HEADER_NAME, correlationId);
 
         try {
             filterChain.doFilter(httpServletRequest, httpServletResponse);
         } finally {
-            MDC.remove(MDCConstants.MDC_CALL_ID);
-            MDC.remove(MDCConstants.MDC_USER_ID);
-            MDC.remove(MDCConstants.MDC_CONSUMER_ID);
+            MDC.remove(MDC_CALL_ID);
+            MDC.remove(MDC_USER_ID);
+            MDC.remove(MDC_CONSUMER_ID);
+            MDC.remove(MDC_CORRELATION_ID);
         }
     }
 
-    private static String generateCallId() {
-        StringBuilder callId = new StringBuilder();
-        callId.append("CallId_");
-        callId.append(System.currentTimeMillis());
-        callId.append("_");
-        callId.append(RANDOM.nextInt(Integer.MAX_VALUE));
-        return callId.toString();
+    private String generateCorrelationId() {
+        return generate("CorrelationId");
+    }
+
+    private String generateCallId() {
+        return generate("CallId");
+    }
+
+    private static String generate(String prefix) {
+        return prefix
+                + "_"
+                + System.currentTimeMillis()
+                + "_"
+                + RANDOM.nextInt(Integer.MAX_VALUE)
+                ;
     }
 
 }

--- a/log/src/main/java/no/nav/log/MDCConstants.java
+++ b/log/src/main/java/no/nav/log/MDCConstants.java
@@ -4,6 +4,7 @@ public interface MDCConstants {
 
     String MDC_USER_ID = "userId";
     String MDC_CONSUMER_ID = "consumerId";
+    String MDC_CORRELATION_ID = "correlationId";
     String MDC_CALL_ID = "callId";
 
 }

--- a/rest/src/main/java/no/nav/sbl/rest/RestUtils.java
+++ b/rest/src/main/java/no/nav/sbl/rest/RestUtils.java
@@ -5,22 +5,28 @@ import lombok.SneakyThrows;
 import lombok.Value;
 import lombok.experimental.Wither;
 import no.nav.json.JsonProvider;
+import no.nav.log.MDCConstants;
 import no.nav.metrics.MetricsFactory;
 import no.nav.metrics.Timer;
 import no.nav.sbl.rest.client.RestRequest;
+import no.nav.sbl.util.StringUtils;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.slf4j.Logger;
+import org.slf4j.MDC;
 
 import javax.net.ssl.SSLContext;
 import javax.ws.rs.client.*;
 import java.io.IOException;
 import java.util.function.Function;
 
+import static no.nav.sbl.util.StringUtils.of;
 import static org.glassfish.jersey.client.ClientProperties.*;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class RestUtils {
+
+    public static final String CORRELATION_ID_HEADER_NAME = "X-Correlation-Id";
 
     private static final Logger LOG = getLogger(RestUtils.class);
 
@@ -115,6 +121,9 @@ public class RestUtils {
 
         @Override
         public void filter(ClientRequestContext clientRequestContext, ClientResponseContext clientResponseContext) throws IOException {
+            of(MDC.get(MDCConstants.MDC_CORRELATION_ID))
+                    .ifPresent(correlationId -> clientRequestContext.getHeaders().putSingle(CORRELATION_ID_HEADER_NAME, correlationId));
+
             Timer timer = (Timer) clientRequestContext.getProperty(NAME);
             timer
                     .stop()


### PR DESCRIPTION
Extended MDCFilter to generate or receive correlation ids to be added to the MDC context.
RestUtils adds the correlation id to any external call by reading the MDC context.