### PR TITLE
Add csrf-header and cookie to allow access to resources protected by CsrfDoubleSubmitCookieFilter

### DIFF
--- a/rest/src/main/java/no/nav/sbl/rest/RestUtils.java
+++ b/rest/src/main/java/no/nav/sbl/rest/RestUtils.java
@@ -8,8 +8,6 @@ import no.nav.json.JsonProvider;
 import no.nav.log.MDCConstants;
 import no.nav.metrics.MetricsFactory;
 import no.nav.metrics.Timer;
-import no.nav.sbl.rest.client.RestRequest;
-import no.nav.sbl.util.StringUtils;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.slf4j.Logger;
@@ -17,9 +15,12 @@ import org.slf4j.MDC;
 
 import javax.net.ssl.SSLContext;
 import javax.ws.rs.client.*;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 import java.util.function.Function;
 
+import static javax.ws.rs.core.HttpHeaders.COOKIE;
 import static no.nav.sbl.util.StringUtils.of;
 import static org.glassfish.jersey.client.ClientProperties.*;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -27,6 +28,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class RestUtils {
 
     public static final String CORRELATION_ID_HEADER_NAME = "X-Correlation-Id";
+    public static final String CSRF_COOKIE_NAVN = "NAV_CSRF_PROTECTION";
 
     private static final Logger LOG = getLogger(RestUtils.class);
 
@@ -112,18 +114,33 @@ public class RestUtils {
 
     private static class MetricsProvider implements ClientResponseFilter, ClientRequestFilter {
 
-        public static final String NAME = MetricsProvider.class.getName();
+        private static final String NAME = MetricsProvider.class.getName();
+        private static final String CSRF_TOKEN = "csrf-token";
         private final String metricName;
 
-        public MetricsProvider(String metricName) {
+        private MetricsProvider(String metricName) {
             this.metricName = metricName;
         }
 
         @Override
-        public void filter(ClientRequestContext clientRequestContext, ClientResponseContext clientResponseContext) throws IOException {
-            of(MDC.get(MDCConstants.MDC_CORRELATION_ID))
-                    .ifPresent(correlationId -> clientRequestContext.getHeaders().putSingle(CORRELATION_ID_HEADER_NAME, correlationId));
+        public void filter(ClientRequestContext clientRequestContext) throws IOException {
+            LOG.info("{} {}", clientRequestContext.getMethod(), clientRequestContext.getUri());
 
+            MultivaluedMap<String, Object> requestHeaders = clientRequestContext.getHeaders();
+
+            of(MDC.get(MDCConstants.MDC_CORRELATION_ID))
+                    .ifPresent(correlationId -> requestHeaders.add(CORRELATION_ID_HEADER_NAME, correlationId));
+
+            requestHeaders.add(CSRF_COOKIE_NAVN, CSRF_TOKEN);
+            requestHeaders.add(COOKIE, new Cookie(CSRF_COOKIE_NAVN,CSRF_TOKEN));
+
+            Timer timer = MetricsFactory.createTimer(this.metricName);
+            timer.start();
+            clientRequestContext.setProperty(NAME, timer);
+        }
+
+        @Override
+        public void filter(ClientRequestContext clientRequestContext, ClientResponseContext clientResponseContext) throws IOException {
             Timer timer = (Timer) clientRequestContext.getProperty(NAME);
             timer
                     .stop()
@@ -133,12 +150,5 @@ public class RestUtils {
                     .report();
         }
 
-        @Override
-        public void filter(ClientRequestContext clientRequestContext) throws IOException {
-            LOG.info("{} {}", clientRequestContext.getMethod(), clientRequestContext.getUri());
-            Timer timer = MetricsFactory.createTimer(this.metricName);
-            timer.start();
-            clientRequestContext.setProperty(NAME, timer);
-        }
     }
 }

--- a/rest/src/test/java/no/nav/sbl/rest/CorrelationIdIntegrationTest.java
+++ b/rest/src/test/java/no/nav/sbl/rest/CorrelationIdIntegrationTest.java
@@ -1,0 +1,52 @@
+package no.nav.sbl.rest;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import no.nav.log.MDCConstants;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.matching.RequestPattern.everything;
+import static no.nav.log.MDCConstants.MDC_CORRELATION_ID;
+import static no.nav.sbl.rest.RestUtils.CORRELATION_ID_HEADER_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CorrelationIdIntegrationTest {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(0);
+
+    @Test
+    public void smoketest() {
+        givenThat(get(urlEqualTo("/"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("ok!"))
+        );
+
+        getRequest();
+
+        String correlationId = CorrelationIdIntegrationTest.class.getName();
+        MDC.put(MDC_CORRELATION_ID, correlationId);
+
+        getRequest();
+
+        List<LoggedRequest> requests = wireMockRule.findRequestsMatching(everything()).getRequests();
+        assertThat(requests).hasSize(2);
+
+        LoggedRequest firstRequest = requests.get(0);
+        assertThat(firstRequest.containsHeader(CORRELATION_ID_HEADER_NAME)).isFalse();
+
+        LoggedRequest secondReauest = requests.get(1);
+        assertThat(secondReauest.getHeader(CORRELATION_ID_HEADER_NAME)).isEqualTo(correlationId);
+    }
+
+    private void getRequest() {
+        RestUtils.withClient(c -> c.target("http://localhost:" + wireMockRule.port()).request().get(String.class));
+    }
+
+}

--- a/rest/src/test/java/no/nav/sbl/rest/CsrfIntegrationTest.java
+++ b/rest/src/test/java/no/nav/sbl/rest/CsrfIntegrationTest.java
@@ -1,0 +1,50 @@
+package no.nav.sbl.rest;
+
+import com.github.tomakehurst.wiremock.http.Cookie;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.matching.RequestPattern.everything;
+import static no.nav.sbl.rest.RestUtils.CSRF_COOKIE_NAVN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CsrfIntegrationTest {
+
+    private static final String REGULAR_COOKIE = "regular-cookie";
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(0);
+
+    @Test
+    public void smoketest() {
+        givenThat(get(urlEqualTo("/"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("ok!"))
+        );
+
+        RestUtils.withClient(c -> c.target("http://localhost:" + wireMockRule.port())
+                .request()
+                .cookie(REGULAR_COOKIE,"someValue")
+                .get(String.class)
+        );
+
+        List<LoggedRequest> requests = wireMockRule.findRequestsMatching(everything()).getRequests();
+        assertThat(requests).hasSize(1);
+        LoggedRequest loggedRequest = requests.get(0);
+
+        Cookie csrfCookie = loggedRequest.getCookies().get(CSRF_COOKIE_NAVN);
+        assertThat(csrfCookie).isNotNull();
+        assertThat(loggedRequest.getHeader(CSRF_COOKIE_NAVN)).isEqualTo(csrfCookie.getValue());
+
+        Cookie regularCookie = loggedRequest.getCookies().get(REGULAR_COOKIE);
+        assertThat(regularCookie).isNotNull();
+        assertThat(regularCookie.getValue()).isNotNull();
+    }
+
+}

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -31,6 +31,10 @@
             <groupId>no.nav.sbl</groupId>
             <artifactId>util</artifactId>
         </dependency>
+        <dependency>
+            <groupId>no.nav.sbl</groupId>
+            <artifactId>rest</artifactId>
+        </dependency>
 
         <!-- Third party dependencies -->
         <dependency>

--- a/web/src/main/java/no/nav/sbl/dialogarena/common/web/security/CsrfDoubleSubmitCookieFilter.java
+++ b/web/src/main/java/no/nav/sbl/dialogarena/common/web/security/CsrfDoubleSubmitCookieFilter.java
@@ -7,11 +7,12 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.*;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.stream;
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static no.nav.sbl.rest.RestUtils.CSRF_COOKIE_NAVN;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -20,7 +21,6 @@ import static org.slf4j.LoggerFactory.getLogger;
  **/
 public class CsrfDoubleSubmitCookieFilter implements Filter {
     private static final Logger LOG = getLogger(CsrfDoubleSubmitCookieFilter.class);
-    private static final String CSRF_COOKIE_NAVN = "NAV_CSRF_PROTECTION";
 
     public static final String IGNORED_URLS_INIT_PARAMETER_NAME = "ignoredUrls";
 


### PR DESCRIPTION
also fixed bug in 75da0f4595c30d086935820347786114d673a308 where correlation-id-header was added
in the response filter, not in the request filter