### PR TITLE
PUS-161 fixed swagger issues

### DIFF
--- a/api-app/pom.xml
+++ b/api-app/pom.xml
@@ -147,6 +147,10 @@
             <artifactId>jersey-server</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>

--- a/api-app/src/main/java/no/nav/apiapp/rest/SwaggerUIServlet.java
+++ b/api-app/src/main/java/no/nav/apiapp/rest/SwaggerUIServlet.java
@@ -41,7 +41,7 @@ public class SwaggerUIServlet extends HttpServlet {
     private void dispatch(String path, HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         LOGGER.info("forward: [{}] -> [{}]", request.getRequestURI(), path);
         RequestDispatcher requestDispatcher = getServletContext().getRequestDispatcher(path);
-        requestDispatcher.include(request, response);
+        requestDispatcher.forward(request, response);
     }
 
 }

--- a/api-app/src/test/java/no/nav/fo/apiapp/ApplicationConfig.java
+++ b/api-app/src/test/java/no/nav/fo/apiapp/ApplicationConfig.java
@@ -72,6 +72,11 @@ public class ApplicationConfig implements NaisApiApplication {
     }
 
     @Bean
+    public RedirectEksempel redirectEksempel() {
+        return new RedirectEksempel();
+    }
+
+    @Bean
     public FeedController feedController() {
         FeedController feedController = new FeedController();
         FeedProducer.FeedProducerBuilder<Integer> feedProducerBuilder = FeedProducer.<Integer>builder().provider((id, pageSize) -> streamTilfeldigInt());

--- a/api-app/src/test/java/no/nav/fo/apiapp/JettyTest.java
+++ b/api-app/src/test/java/no/nav/fo/apiapp/JettyTest.java
@@ -11,6 +11,7 @@ import no.nav.sbl.dialogarena.common.cxf.StsSecurityConstants;
 import no.nav.sbl.dialogarena.common.jetty.Jetty;
 import no.nav.testconfig.ApiAppTest;
 import org.eclipse.jetty.server.ServerConnector;
+import org.glassfish.jersey.client.ClientProperties;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +58,11 @@ public abstract class JettyTest {
         return apiApp.getJetty();
     }
 
-    private Client client = ClientBuilder.newBuilder().register(new JsonProvider()).build();
+    private Client client = ClientBuilder.newBuilder()
+            .register(new JsonProvider())
+            .property(ClientProperties.FOLLOW_REDIRECTS, "false")
+            .build();
+
     private Map<String, NewCookie> cookies = new HashMap<>();
 
     @BeforeClass

--- a/api-app/src/test/java/no/nav/fo/apiapp/rest/RedirectEksempel.java
+++ b/api-app/src/test/java/no/nav/fo/apiapp/rest/RedirectEksempel.java
@@ -1,0 +1,25 @@
+package no.nav.fo.apiapp.rest;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+
+import static no.nav.fo.apiapp.ApplicationConfig.APPLICATION_NAME;
+
+@Path("/redirect")
+public class RedirectEksempel {
+
+    @GET
+    public Response redirect(@Context UriInfo uriBuilder) {
+        URI build = uriBuilder.getRequestUriBuilder()
+                .replacePath(APPLICATION_NAME)
+                .path("api")
+                .path("ping")
+                .build();
+        return Response.temporaryRedirect(build).build();
+    }
+
+}

--- a/api-app/src/test/java/no/nav/fo/apiapp/rest/RedirectTest.java
+++ b/api-app/src/test/java/no/nav/fo/apiapp/rest/RedirectTest.java
@@ -1,0 +1,29 @@
+package no.nav.fo.apiapp.rest;
+
+import no.nav.fo.apiapp.JettyTest;
+import org.junit.Test;
+
+import javax.ws.rs.client.SyncInvoker;
+import javax.ws.rs.core.Response;
+
+import java.net.URI;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class RedirectTest extends JettyTest {
+
+    @Test
+    public void get() {
+        Response response = getResponse();
+        assertThat(response.getStatus(), equalTo(307));
+        URI location = response.getLocation();
+        assertThat(location.getScheme(), equalTo("testscheme"));
+    }
+
+    private Response getResponse() {
+        String path = "/api/redirect";
+        return request(path, builder -> builder.header("X-Forwarded-Proto","testscheme").get());
+    }
+
+}

--- a/api-app/src/test/resources/SwaggerTest.default.json
+++ b/api-app/src/test/resources/SwaggerTest.default.json
@@ -161,6 +161,21 @@
         }
       }
     },
+    "/redirect": {
+      "get": {
+        "tags": [
+          "RedirectEksempel"
+        ],
+        "summary": "redirect",
+        "operationId": "redirect",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
     "/enum/{ordinal}": {
       "get": {
         "tags": [

--- a/api-app/src/test/resources/SwaggerTest.json
+++ b/api-app/src/test/resources/SwaggerTest.json
@@ -161,6 +161,21 @@
         }
       }
     },
+    "/redirect": {
+      "get": {
+        "tags": [
+          "RedirectEksempel"
+        ],
+        "summary": "redirect",
+        "operationId": "redirect",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
     "/enum/dto/{ordinal}": {
       "get": {
         "tags": [


### PR DESCRIPTION
 - RequestDispatcher.include() does not set a content-type on the response and without it, kubernetes defaults it (wrongly) to application/x-gzip. Avoid this by using RequestDispatcher.forward()
 - Added support for X-Forwarded headers, so that redirects work correctly

Also, deactivate jetty caches only in development mode