### PR TITLE
prevent invalid caching of saml tokens

### DIFF
--- a/cxf/src/main/java/no/nav/sbl/dialogarena/common/cxf/NAVOidcSTSClient.java
+++ b/cxf/src/main/java/no/nav/sbl/dialogarena/common/cxf/NAVOidcSTSClient.java
@@ -1,8 +1,9 @@
 package no.nav.sbl.dialogarena.common.cxf;
 
 import no.nav.brukerdialog.security.context.SubjectHandler;
-import no.nav.sbl.util.StringUtils;
+import no.nav.common.auth.SsoToken;
 import no.nav.sbl.dialogarena.common.cxf.saml.ClaimsCallbackHandler;
+import no.nav.sbl.util.StringUtils;
 import org.apache.cxf.Bus;
 import org.apache.cxf.ws.security.SecurityConstants;
 import org.apache.cxf.ws.security.tokenstore.MemoryTokenStoreFactory;
@@ -12,6 +13,7 @@ import org.apache.cxf.ws.security.trust.STSClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static no.nav.common.auth.SubjectHandler.getSsoToken;
 import static no.nav.sbl.dialogarena.common.cxf.StsType.SYSTEM_USER_IN_FSS;
 
 public class NAVOidcSTSClient extends STSClient {
@@ -62,14 +64,10 @@ public class NAVOidcSTSClient extends STSClient {
     private String getUserKey() {
         if (stsType == SYSTEM_USER_IN_FSS) {
             return "systemSAML";
-        }
-
-        String internSsoToken = SubjectHandler.getSubjectHandler().getInternSsoToken();
-        if (internSsoToken == null) {
-            logger.info("Finner ingen OIDC, henter SAML som systembruker");
-            return "systemSAML";
         } else {
-            return internSsoToken;
+            return getSsoToken()
+                    .map(SsoToken::getToken)
+                    .orElseThrow(() -> new IllegalStateException("Finner ingen sso token som kan bli cache-nøkkel for brukerens SAML-token"));
         }
     }
 

--- a/cxf/src/main/java/no/nav/sbl/dialogarena/common/cxf/STSConfigurationUtil.java
+++ b/cxf/src/main/java/no/nav/sbl/dialogarena/common/cxf/STSConfigurationUtil.java
@@ -45,6 +45,7 @@ public class STSConfigurationUtil {
 
         STSClient stsClient = createBasicSTSClient(client.getBus(), location, username, password, stsType);
         client.getRequestContext().put(SecurityConstants.STS_CLIENT, stsClient);
+        client.getRequestContext().put(SecurityConstants.CACHE_ISSUED_TOKEN_IN_ENDPOINT, stsType.allowCachingInEndpoint());
         setEndpointPolicyReference(client, "classpath:stspolicy.xml");
     }
 

--- a/cxf/src/main/java/no/nav/sbl/dialogarena/common/cxf/StsType.java
+++ b/cxf/src/main/java/no/nav/sbl/dialogarena/common/cxf/StsType.java
@@ -3,5 +3,10 @@ package no.nav.sbl.dialogarena.common.cxf;
 public enum StsType {
     SYSTEM_USER_IN_FSS,
     ON_BEHALF_OF_WITH_JWT,
-    EXTERNAL_SSO
+    EXTERNAL_SSO;
+
+    public boolean allowCachingInEndpoint() {
+        return this == SYSTEM_USER_IN_FSS;
+    }
+
 }


### PR DESCRIPTION
 - No not cache saml-tokens for external sso in endpoint
 - Do default to "systemSAML" as user cache key when sso is unavailable - throw exception