### PR TITLE
[PUS-180] Legger inn støtte for millisekunder ved logging gjennom syslog

### DIFF
--- a/api-app/pom.xml
+++ b/api-app/pom.xml
@@ -273,6 +273,12 @@
             <version>4.10</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>com.spotify</groupId>
+            <artifactId>logging</artifactId>
+            <version>2.2.4</version>
+            <scope>runtime</scope>
+        </dependency>
         <!-- kreves for betinget konfigurasjon av logback -->
         <dependency>
             <groupId>org.codehaus.janino</groupId>

--- a/api-app/src/main/resources/logback-default.xml
+++ b/api-app/src/main/resources/logback-default.xml
@@ -31,7 +31,7 @@
         </sift>
     </appender>
 
-    <appender name="syslog" class="ch.qos.logback.classic.net.SyslogAppender">
+    <appender name="syslog" class="com.spotify.logging.logback.MillisecondPrecisionSyslogAppender">
         <syslogHost>localhost</syslogHost>
         <facility>LOCAL1</facility>
         <throwableExcluded>true</throwableExcluded>


### PR DESCRIPTION
Legger inn støtte for millisekunder ved logging gjennom syslog ved å bruke com.spotify.logging.logback.MillisecondPrecisionSyslogAppender