### PR TITLE
Muliggjør å spørre om tilgang til udefinerte enheter

### DIFF
--- a/api-app/src/main/java/no/nav/apiapp/security/PepClient.java
+++ b/api-app/src/main/java/no/nav/apiapp/security/PepClient.java
@@ -59,7 +59,12 @@ public class PepClient {
         BiasedDecisionResponse r = pep.harTilgang(pep.nyRequest()
                 .withResourceType(ResourceType.Enhet)
                 .withDomain(applicationDomain)
-                .withEnhet(enhet));
+                // ABAC feiler hvis man spør om tilgang til udefinerte enheter (null) men tillater å spørre om tilgang
+                // til enheter som ikke finnes (f.eks. tom streng)
+                // Ved å konvertere null til tom streng muliggjør vi å spørre om tilgang til enhet for brukere som
+                // ikke har enhet. Sluttbrukere da få permit mens veiledere vil få deny.
+                .withEnhet(ofNullable(enhet).orElse(""))
+        );
         return erPermit(r);
     }
 

--- a/api-app/src/test/java/no/nav/apiapp/TestData.java
+++ b/api-app/src/test/java/no/nav/apiapp/TestData.java
@@ -5,6 +5,7 @@ public class TestData {
     public static final String LITE_PRIVELIGERT_VEILEDER_ALIAS = "lite_priveligert_veileder";
     public static final String PRIVELIGERT_VEILEDER_ALIAS = "priveligert_veileder";
     public static final String BRUKER_UNDER_OPPFOLGING_ALIAS = "bruker_under_oppfolging";
+    public static final String SENTRAL_ENHET_ALIAS = "sentral_enhet";
 
 }
 

--- a/api-app/src/test/java/no/nav/apiapp/security/PepClientTester.java
+++ b/api-app/src/test/java/no/nav/apiapp/security/PepClientTester.java
@@ -1,5 +1,6 @@
 package no.nav.apiapp.security;
 
+import lombok.SneakyThrows;
 import no.nav.apiapp.feil.IngenTilgang;
 import no.nav.brukerdialog.security.context.SubjectExtension;
 import no.nav.brukerdialog.security.domain.IdentType;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static no.nav.apiapp.TestData.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SuppressWarnings("unused")
@@ -45,6 +47,33 @@ public interface PepClientTester {
         setVeilederFraFasitAlias(LITE_PRIVELIGERT_VEILEDER_ALIAS, subjectExtension);
         PepClient pepClient = getPepClient();
         assertThatThrownBy(() -> pepClient.sjekkLeseTilgangTilFnr(hentFnrFraFasit())).isExactlyInstanceOf(IngenTilgang.class);
+    }
+
+    @Test
+    @SneakyThrows
+    default void harTilgangTilEnhet_veilederHarTilgang(SubjectExtension.SubjectStore subjectExtension) {
+        setVeilederFraFasitAlias(PRIVELIGERT_VEILEDER_ALIAS, subjectExtension);
+        String sentralEnhet = FasitUtils.getTestDataProperty(SENTRAL_ENHET_ALIAS).orElseThrow(IllegalStateException::new);
+        PepClient pepClient = getPepClient();
+        assertThat(pepClient.harTilgangTilEnhet(sentralEnhet)).isTrue();
+    }
+
+    @Test
+    @SneakyThrows
+    default void harTilgangTilEnhet_veilederHarIkkeTilgang(SubjectExtension.SubjectStore subjectExtension) {
+        setVeilederFraFasitAlias(LITE_PRIVELIGERT_VEILEDER_ALIAS, subjectExtension);
+        String sentralEnhet = FasitUtils.getTestDataProperty(SENTRAL_ENHET_ALIAS).orElseThrow(IllegalStateException::new);
+        PepClient pepClient = getPepClient();
+        assertThat(pepClient.harTilgangTilEnhet(sentralEnhet)).isFalse();
+    }
+
+    @Test
+    @SneakyThrows
+    default void harTilgangTilEnhet__mangler_enhet__veilederHarIkkeTilgang(SubjectExtension.SubjectStore subjectExtension) {
+        setVeilederFraFasitAlias(PRIVELIGERT_VEILEDER_ALIAS, subjectExtension);
+        PepClient pepClient = getPepClient();
+        assertThat(pepClient.harTilgangTilEnhet(null)).isFalse();
+        assertThat(pepClient.harTilgangTilEnhet("")).isFalse();
     }
 
 }

--- a/fasit/src/main/java/no/nav/dialogarena/config/fasit/FasitUtils.java
+++ b/fasit/src/main/java/no/nav/dialogarena/config/fasit/FasitUtils.java
@@ -9,6 +9,7 @@ import no.nav.dialogarena.config.fasit.client.FasitClient;
 import no.nav.dialogarena.config.fasit.client.FasitClientImpl;
 import no.nav.dialogarena.config.fasit.client.FasitClientMock;
 import no.nav.dialogarena.config.fasit.dto.RestService;
+import no.nav.sbl.util.StringUtils;
 import org.slf4j.Logger;
 
 import java.io.File;
@@ -47,6 +48,8 @@ public class FasitUtils {
 
     private static final List<String> T_DOMAINS = Arrays.asList(OERA_T_LOCAL, TEST_LOCAL);
     private static final List<String> Q_DOMAINS = Arrays.asList(OERA_Q_LOCAL, PREPROD_LOCAL);
+
+    public static final String TEST_DATA_ALIAS = "test_data";
 
     static {
         objectMapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -268,6 +271,21 @@ public class FasitUtils {
         );
     }
 
+    public static Optional<String> getTestDataProperty(String propertyName) {
+        return ofNullable(getTestDataProperties().getProperty(propertyName)).filter(StringUtils::notNullOrEmpty);
+    }
+
+    public static Properties getTestDataProperties() {
+        return getApplicationProperties(TEST_DATA_ALIAS);
+    }
+
+    public static Properties getApplicationProperties(String alias) {
+        return getFasitClient().getApplicationProperties(FasitClient.GetApplicationPropertiesRequest.builder()
+                .alias(alias)
+                .environmentClass(getDefaultEnvironmentClass())
+                .build()
+        );
+    }
 
     public static String getFasitPassword() {
         return getVariable(FASIT_PASSWORD_VARIABLE_NAME);

--- a/fasit/src/main/java/no/nav/dialogarena/config/fasit/client/ApplicationPropertiesDTO.java
+++ b/fasit/src/main/java/no/nav/dialogarena/config/fasit/client/ApplicationPropertiesDTO.java
@@ -1,0 +1,15 @@
+package no.nav.dialogarena.config.fasit.client;
+
+import javax.ws.rs.core.GenericType;
+import java.util.List;
+
+public class ApplicationPropertiesDTO {
+    public static final GenericType<List<ApplicationPropertiesDTO>> LIST_TYPE = new GenericType<List<ApplicationPropertiesDTO>>() {};
+
+    public Properties properties;
+
+    public static class Properties {
+        public String applicationProperties;
+    }
+
+}

--- a/fasit/src/main/java/no/nav/dialogarena/config/fasit/client/FasitClient.java
+++ b/fasit/src/main/java/no/nav/dialogarena/config/fasit/client/FasitClient.java
@@ -20,6 +20,7 @@ public interface FasitClient {
     ServiceUser getCredentials(GetCredentialsRequest getCredentialsRequest);
     ApplicationConfig getApplicationConfig(GetApplicationConfigRequest getApplicationConfigRequest);
     Properties getApplicationEnvironment(GetApplicationEnvironmentRequest getApplicationEnvironmentRequest);
+    Properties getApplicationProperties(GetApplicationPropertiesRequest getApplicationPropertiesRequest);
     LdapConfig getLdapConfig(String environmentClass);
 
 
@@ -67,6 +68,13 @@ public interface FasitClient {
     class GetApplicationEnvironmentRequest {
         public String applicationName;
         public String environment;
+    }
+
+    @Builder
+    @Value
+    class GetApplicationPropertiesRequest {
+        public String alias;
+        public String environmentClass;
     }
 
 }

--- a/fasit/src/main/java/no/nav/dialogarena/config/fasit/client/FasitClientMock.java
+++ b/fasit/src/main/java/no/nav/dialogarena/config/fasit/client/FasitClientMock.java
@@ -69,6 +69,11 @@ public class FasitClientMock implements FasitClient {
         throw new IllegalStateException();
     }
 
+    @Override
+    public Properties getApplicationProperties(GetApplicationPropertiesRequest getApplicationPropertiesRequest) {
+        throw new IllegalStateException();
+    }
+
     private String mockUrl(String alias) {
         return String.format("http://localhost:8080/mock/%s", alias);
     }

--- a/fasit/src/test/java/no/nav/dialogarena/config/fasit/FasitUtilsIntegrationTest.java
+++ b/fasit/src/test/java/no/nav/dialogarena/config/fasit/FasitUtilsIntegrationTest.java
@@ -225,4 +225,10 @@ public class FasitUtilsIntegrationTest {
         assertThat(FasitUtils.getWebServiceEndpoint("Aktoer_v2").url, not(isEmptyOrNullString()));
     }
 
+    @Test
+    public void getTestDataProperty_() {
+        assertThat(FasitUtils.getTestDataProperty("sentral_enhet").get(),not(isEmptyOrNullString()));
+        assertThat(FasitUtils.getTestDataProperty("not_existing_property").isPresent(),is(false));
+    }
+
 }


### PR DESCRIPTION
ABAC feiler hvis man spør om tilgang til udefinerte enheter (null) men tillater å spørre om tilgang
til enheter som ikke finnes (f.eks. tom streng)
Ved å konvertere null til tom streng muliggjør vi å spørre om tilgang til enhet for brukere som
ikke har enhet. Sluttbrukere da få permit mens veiledere vil få deny.