### PR TITLE
common-cxf dependency on jetty should be test-scoped

### DIFF
--- a/cxf/pom.xml
+++ b/cxf/pom.xml
@@ -145,22 +145,6 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
         </dependency>
-        <dependency>
-            <groupId>no.nav.sbl.dialogarena</groupId>
-            <artifactId>common-jetty</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-        </dependency>
 
         <!-- test -->
         <dependency>
@@ -176,6 +160,27 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>no.nav.sbl.dialogarena</groupId>
+            <artifactId>common-jetty</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/cxf/src/main/java/no/nav/sbl/dialogarena/common/cxf/OnBehalfOfWithOidcCallbackHandler.java
+++ b/cxf/src/main/java/no/nav/sbl/dialogarena/common/cxf/OnBehalfOfWithOidcCallbackHandler.java
@@ -1,8 +1,6 @@
 package no.nav.sbl.dialogarena.common.cxf;
 
 
-import no.nav.brukerdialog.security.oidc.OidcTokenUtils;
-import no.nav.common.auth.SsoToken;
 import no.nav.common.auth.Subject;
 import org.apache.cxf.ws.security.trust.delegation.DelegationCallback;
 import org.slf4j.Logger;


### PR DESCRIPTION
since it uses jetty for integrations tests only