### PR TITLE
QueryMapping; soon-to-be hibernate™

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -76,6 +76,10 @@
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/jdbc/src/main/java/no/nav/sbl/sql/SqlUtils.java
+++ b/jdbc/src/main/java/no/nav/sbl/sql/SqlUtils.java
@@ -1,5 +1,7 @@
 package no.nav.sbl.sql;
 
+import no.nav.sbl.sql.mapping.QueryMapping;
+import no.nav.sbl.sql.mapping.SqlRecord;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.sql.ResultSet;
@@ -28,6 +30,15 @@ public class SqlUtils {
 
     public static <T> SelectQuery<T> select(JdbcTemplate db, String tableName, SQLFunction<ResultSet, T> mapper) {
         return new SelectQuery<>(db, tableName, mapper);
+    }
+
+    public static <T extends SqlRecord> SelectQuery<T> select(JdbcTemplate db, String tableName, Class<T> recordClass) {
+        QueryMapping<T> querymapping = QueryMapping.of(recordClass);
+
+        SelectQuery<T> selectQuery = new SelectQuery<>(db, tableName, querymapping::createMapper);
+        querymapping.applyColumn(selectQuery);
+
+        return selectQuery;
     }
 
     public static SelectQuery<Long> nextFromSeq(JdbcTemplate db, String sekvens) {

--- a/jdbc/src/main/java/no/nav/sbl/sql/mapping/QueryMapping.java
+++ b/jdbc/src/main/java/no/nav/sbl/sql/mapping/QueryMapping.java
@@ -1,0 +1,162 @@
+package no.nav.sbl.sql.mapping;
+
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import io.vavr.collection.HashMap;
+import io.vavr.collection.List;
+import io.vavr.collection.Map;
+import io.vavr.control.Option;
+import io.vavr.control.Try;
+import lombok.Value;
+import no.nav.sbl.sql.SelectQuery;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.sql.ResultSet;
+import java.util.Arrays;
+
+public class QueryMapping<T extends SqlRecord> {
+    private static List<String> ignoreFields = List.of("$jacocoData");
+    private static Map<Class<? extends SqlRecord>, QueryMapping<? extends SqlRecord>> mappers = HashMap.empty();
+    private Class<T> targetClass;
+    private List<InternalColumn> columns;
+    private Constructor<T> constructor;
+
+    private QueryMapping(Class<T> targetClass) {
+        this.targetClass = targetClass;
+        this.columns = getColumns();
+        this.constructor = getConstructor();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T extends SqlRecord> QueryMapping<T> of(Class<T> targetClass) {
+        if (!mappers.containsKey(targetClass)) {
+            mappers = mappers.put(targetClass, new QueryMapping<>(targetClass));
+        }
+
+        return (QueryMapping<T>) mappers.get(targetClass).getOrNull();
+    }
+
+    public SelectQuery<T> applyColumn(SelectQuery<T> query) {
+        columns.forEach((column) -> query.column(column.name));
+        return query;
+    }
+
+    public T createMapper(ResultSet rs) {
+        return Try.of(() -> {
+            Object[] parameters = columns.map((column) -> deserialize(column, rs)).toJavaArray();
+
+            return constructor.newInstance(parameters);
+        }).getOrElseThrow((err) -> new RuntimeException("Failed to deserialize", err));
+    }
+
+    public static <FROM, TO> void register(Class<FROM> fromCls, Class<TO> toCls, TypeMapping.Deserializer<FROM, TO> deserializer) {
+        TypeMapping.register(fromCls, toCls, deserializer);
+    }
+
+    private <FROM, TO> Column<FROM, TO> deserialize(InternalColumn<FROM, TO> column, ResultSet rs) {
+        FROM value = ValueMapping.getValue(column, rs);
+        return Column.of(TypeMapping.convert(value, column));
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<InternalColumn> getColumns() {
+        List<Field> fields = List.of(targetClass.getDeclaredFields())
+                .filter((field) -> !ignoreFields.contains(field.getName()));
+
+        verifyFields(fields);
+
+        return fields
+                .map((field) -> {
+                    String name = field.getName();
+                    Type[] genericTypes = ((ParameterizedType) field.getAnnotatedType().getType()).getActualTypeArguments();
+                    Class from = ((Class) genericTypes[0]);
+                    Class to = ((Class) genericTypes[1]);
+                    return new InternalColumn(name, from, to);
+                });
+    }
+
+    @SuppressWarnings("unchecked")
+    private Constructor<T> getConstructor() {
+        InternalColumn[] parameterTypes = this.columns.toJavaArray(InternalColumn.class);
+
+        Constructor<T> constructor = findConstructorWithParamLength(targetClass, parameterTypes.length);
+        verifyConstructorParameters(constructor, parameterTypes);
+
+        return constructor;
+    }
+
+    private static void verifyFields(List<Field> fields) {
+        Option<Field> brokenField = fields
+                .find((field) -> !Column.class.isAssignableFrom(field.getType()));
+
+
+        if (brokenField.isDefined()) {
+            throw new IllegalArgumentException("targetClass contains non-column fields " + brokenField);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Constructor<T> findConstructorWithParamLength(Class<T> targetClass, int targetLength) {
+        List<Constructor<?>> constructors = List.of(targetClass.getConstructors())
+                .filter((constructor) -> constructor.getParameterCount() == targetLength);
+
+        if (constructors.length() != 1) {
+            throw new IllegalArgumentException("Found " + constructors.length() + " constructors with " + targetLength + "parameters. Expected just one.");
+        }
+
+        return (Constructor<T>) constructors.get(0);
+    }
+
+    private static <T> void verifyConstructorParameters(Constructor<T> constructor, InternalColumn[] parameterTypes) {
+        List<Type> constructorTypes = List.of(constructor.getGenericParameterTypes());
+
+        verifyParameterBaseType(constructorTypes, parameterTypes);
+        verifyParameterGenericType(constructorTypes, parameterTypes);
+    }
+
+    private static void verifyParameterBaseType(List<Type> constructorTypes, InternalColumn[] parameterTypes) {
+        int nonGenericConstructorTypes = constructorTypes
+                .filter((cls) -> !(cls instanceof ParameterizedType))
+                .length();
+
+        if (nonGenericConstructorTypes > 0) {
+            String msg = "Constructor parameter mismatch, expected " + Arrays.toString(parameterTypes) + " found: " + constructorTypes;
+            throw new IllegalArgumentException(msg);
+        }
+    }
+
+    private static void verifyParameterGenericType(List<Type> constructorTypes, InternalColumn[] parameterTypes) {
+        List<Tuple2<Class, Class>> constructorGenericTypes = constructorTypes
+                .map((param) -> {
+                    Type[] genericTypes = ((ParameterizedType) param).getActualTypeArguments();
+                    Class from = ((Class) genericTypes[0]);
+                    Class to = ((Class) genericTypes[1]);
+                    return Tuple.of(from, to);
+                });
+
+        for (int i = 0; i < parameterTypes.length; i++) {
+            InternalColumn paramType = parameterTypes[i];
+            Tuple2<Class, Class> constructorType = constructorGenericTypes.get(i);
+
+            if (!(paramType.from.equals(constructorType._1) && paramType.to.equals(constructorType._2))) {
+                String msg = "Constructor parameter mismatch, expected " + Arrays.toString(parameterTypes) + " found: " + constructorTypes;
+                throw new IllegalArgumentException(msg);
+            }
+        }
+    }
+
+    @Value(staticConstructor = "of")
+    static class InternalColumn<FROM, TO> {
+        public String name;
+        public Class<FROM> from;
+        public Class<TO> to;
+    }
+
+    @Value(staticConstructor = "of")
+    public static class Column<FROM, TO> {
+        public TO value;
+    }
+}

--- a/jdbc/src/main/java/no/nav/sbl/sql/mapping/SqlRecord.java
+++ b/jdbc/src/main/java/no/nav/sbl/sql/mapping/SqlRecord.java
@@ -1,0 +1,4 @@
+package no.nav.sbl.sql.mapping;
+
+public interface SqlRecord {
+}

--- a/jdbc/src/main/java/no/nav/sbl/sql/mapping/TypeMapping.java
+++ b/jdbc/src/main/java/no/nav/sbl/sql/mapping/TypeMapping.java
@@ -1,0 +1,58 @@
+package no.nav.sbl.sql.mapping;
+
+import io.vavr.collection.HashMap;
+import io.vavr.collection.Map;
+
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.*;
+import java.util.function.Function;
+
+class TypeMapping {
+    public interface Deserializer<FROM, TO> extends Function<FROM, TO> {
+    }
+
+    static Map<Class<?>, Map<Class<?>, Deserializer<?, ?>>> typemappers = HashMap.empty();
+
+    static {
+        registerDefaults();
+    }
+
+    static <FROM, TO> void register(Class<FROM> fromCls, Class<TO> toCls, Deserializer<FROM, TO> deserializer) {
+        Map<Class<?>, Deserializer<?, ?>> toMap = TypeMapping.typemappers.get(fromCls).getOrElse(HashMap.empty());
+        toMap = toMap.put(toCls, deserializer);
+        TypeMapping.typemappers = TypeMapping.typemappers.put(fromCls, toMap);
+    }
+
+    @SuppressWarnings("unchecked")
+    static  <TO, FROM> TO convert(FROM value, QueryMapping.InternalColumn<FROM, TO> column) {
+        if (column.from == column.to) {
+            return (TO) value;
+        }
+
+        Deserializer<FROM, TO> deserializer = (Deserializer<FROM, TO>) typemappers
+                .get(column.from)
+                .flatMap((toMap) -> toMap.get(column.to))
+                .getOrElseThrow(() -> new IllegalStateException("Could not find serializer for " + column));
+
+        try {
+            return deserializer.apply(value);
+        } catch (NullPointerException e) {
+            if (value == null) {
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    static void registerDefaults() {
+        register(Date.class, LocalDate.class, Date::toLocalDate);
+        register(Time.class, LocalTime.class, Time::toLocalTime);
+        register(Timestamp.class, LocalDateTime.class, Timestamp::toLocalDateTime);
+        register(Timestamp.class, ZonedDateTime.class, (time) -> time.toLocalDateTime().atZone(ZoneId.systemDefault()));
+
+        register(Integer.class, Boolean.class, (value) -> value == 1);
+        register(String.class, Boolean.class, (str) -> "J".equalsIgnoreCase(str) || "true".equalsIgnoreCase(str));
+    }
+}

--- a/jdbc/src/main/java/no/nav/sbl/sql/mapping/ValueMapping.java
+++ b/jdbc/src/main/java/no/nav/sbl/sql/mapping/ValueMapping.java
@@ -1,0 +1,42 @@
+package no.nav.sbl.sql.mapping;
+
+import io.vavr.CheckedFunction2;
+import io.vavr.collection.HashMap;
+import io.vavr.collection.Map;
+
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.*;
+
+class ValueMapping {
+    private static Map<Class<?>, CheckedFunction2<ResultSet, String, ?>> valuemappers = HashMap.empty();
+
+    static {
+        valuemappers = valuemappers.put(String.class, ResultSet::getString);
+        valuemappers = valuemappers.put(Boolean.class, ResultSet::getBoolean);
+        valuemappers = valuemappers.put(Integer.class, ResultSet::getInt);
+        valuemappers = valuemappers.put(Byte.class, ResultSet::getByte);
+        valuemappers = valuemappers.put(Byte[].class, ResultSet::getBytes);
+        valuemappers = valuemappers.put(Double.class, ResultSet::getDouble);
+        valuemappers = valuemappers.put(Float.class, ResultSet::getFloat);
+        valuemappers = valuemappers.put(Long.class, ResultSet::getLong);
+        valuemappers = valuemappers.put(Short.class, ResultSet::getShort);
+        valuemappers = valuemappers.put(Object.class, ResultSet::getObject);
+        valuemappers = valuemappers.put(BigDecimal.class, ResultSet::getBigDecimal);
+        valuemappers = valuemappers.put(Time.class, ResultSet::getTime);
+        valuemappers = valuemappers.put(Timestamp.class, ResultSet::getTimestamp);
+        valuemappers = valuemappers.put(Date.class, ResultSet::getDate);
+        valuemappers = valuemappers.put(URL.class, ResultSet::getURL);
+        valuemappers = valuemappers.put(Blob.class, ResultSet::getBlob);
+        valuemappers = valuemappers.put(Clob.class, ResultSet::getBlob);
+    }
+
+    @SuppressWarnings("unchecked")
+    static <FROM> FROM getValue(QueryMapping.InternalColumn<FROM, ?> column, ResultSet rs) {
+        return (FROM) valuemappers
+                .get(column.from)
+                .toTry(() -> new RuntimeException("Mapping from " + column.from + " not found."))
+                .mapTry((func) -> func.apply(rs, column.name))
+                .get();
+    }
+}

--- a/jdbc/src/test/java/no/nav/sbl/sql/SqlUtilsTest.java
+++ b/jdbc/src/test/java/no/nav/sbl/sql/SqlUtilsTest.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SqlUtilsTest {
 

--- a/jdbc/src/test/java/no/nav/sbl/sql/UpsertQueryTest.java
+++ b/jdbc/src/test/java/no/nav/sbl/sql/UpsertQueryTest.java
@@ -13,7 +13,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class UpsertQueryTest {
     public final static String TESTTABLE1 = "TESTTABLE1";

--- a/jdbc/src/test/java/no/nav/sbl/sql/mapping/QueryMappingTest.java
+++ b/jdbc/src/test/java/no/nav/sbl/sql/mapping/QueryMappingTest.java
@@ -1,0 +1,118 @@
+package no.nav.sbl.sql.mapping;
+
+import lombok.Value;
+import no.nav.sbl.sql.SelectQuery;
+import no.nav.sbl.sql.mapping.QueryMapping.Column;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class QueryMappingTest {
+
+    @Test
+    public void should_not_create_multiple_mappers_of_same_type() {
+        QueryMapping<TestRecord> mapper = QueryMapping.of(TestRecord.class);
+        QueryMapping<TestRecord> mapper2 = QueryMapping.of(TestRecord.class);
+
+        assertThat(mapper == mapper2).isTrue();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_throw_error_for_non_column_types() {
+        QueryMapping.of(NonSupportedFieldRecord.class);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_throw_if_a_matching_constructor_is_not_found() {
+        QueryMapping.of(NoMatchingConstructorRecord.class);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_throw_if_a_matching_constructor_is_not_found2() {
+        QueryMapping.of(NoMatchingConstructorRecord2.class);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_throw_if_a_matching_constructor_is_not_found3() {
+        QueryMapping.of(MultipleConstructorRecord.class);
+    }
+
+    @Test
+    public void should_add_columns_based_on_field_names() {
+        ArgumentCaptor<String> names = ArgumentCaptor.forClass(String.class);
+        SelectQuery query = mock(SelectQuery.class);
+        when(query.column(names.capture())).thenReturn(query);
+
+        QueryMapping.of(TestRecord.class).applyColumn(query);
+
+        verify(query, times(3)).column(anyString());
+        assertThat(names.getAllValues()).isEqualTo(Arrays.asList("name", "age", "birth"));
+    }
+
+    @Test
+    public void should_create_resultset_mapper() throws SQLException {
+        LocalDate now = LocalDate.now();
+
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.getString(anyString())).thenReturn("Bruce Wayne");
+        when(rs.getInt(anyString())).thenReturn(42);
+        when(rs.getDate(anyString())).thenReturn(Date.valueOf(now));
+
+        TestRecord record = QueryMapping.of(TestRecord.class).createMapper(rs);
+
+        assertThat(record.name.value).isEqualTo("Bruce Wayne");
+        assertThat(record.age.value).isEqualTo(42);
+        assertThat(record.birth.value).isEqualTo(now);
+    }
+
+    @Value
+    static class TestRecord implements SqlRecord {
+        Column<String, String> name;
+        Column<Integer, Integer> age;
+        Column<Date, LocalDate> birth;
+    }
+
+    @Value
+    static class NonSupportedFieldRecord implements SqlRecord {
+        String name;
+    }
+
+    static class NoMatchingConstructorRecord implements SqlRecord {
+        Column<String, Boolean> name;
+
+        public NoMatchingConstructorRecord(Column<String, LocalDate> name) {
+
+        }
+    }
+
+    static class NoMatchingConstructorRecord2 implements SqlRecord {
+        Column<String, Boolean> name;
+
+        public NoMatchingConstructorRecord2(String name) {
+
+        }
+    }
+    static class MultipleConstructorRecord implements SqlRecord {
+        Column<String, Boolean> name;
+
+        public MultipleConstructorRecord(String name) {
+
+        }
+
+        public MultipleConstructorRecord(Boolean name) {
+
+        }
+    }
+
+    static <FROM, TO> QueryMapping.InternalColumn<FROM, TO> column(Class<FROM> fromCls, Class<TO> toCls) {
+        return QueryMapping.InternalColumn.of("name", fromCls, toCls);
+    }
+}

--- a/jdbc/src/test/java/no/nav/sbl/sql/mapping/TypeMappingTest.java
+++ b/jdbc/src/test/java/no/nav/sbl/sql/mapping/TypeMappingTest.java
@@ -1,0 +1,111 @@
+package no.nav.sbl.sql.mapping;
+
+import io.vavr.collection.HashMap;
+import org.junit.After;
+import org.junit.Test;
+
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.*;
+
+import static no.nav.sbl.sql.mapping.QueryMappingTest.column;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TypeMappingTest {
+    @After
+    public void after_each() {
+        TypeMapping.typemappers = HashMap.empty();
+        TypeMapping.registerDefaults();
+    }
+
+    @Test
+    public void should_register_mapper() {
+        TypeMapping.register(Character.class, String.class, Object::toString);
+        String string = TypeMapping.convert('C', column(Character.class, String.class));
+
+        assertThat(string).isEqualTo("C");
+    }
+
+    @Test
+    public void should_override_mapper() {
+        TypeMapping.register(Character.class, String.class, Object::toString);
+        String string = TypeMapping.convert('C', column(Character.class, String.class));
+
+        assertThat(string).isEqualTo("C");
+
+        TypeMapping.register(Character.class, String.class, (ch) -> ch.toString().toLowerCase());
+        String string2 = TypeMapping.convert('C', column(Character.class, String.class));
+
+        assertThat(string2).isEqualTo("c");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void should_throw_on_unknown_mapper() {
+        TypeMapping.convert('C', column(Character.class, String.class));
+    }
+
+    @Test
+    public void should_handle_all_identity_mappings() {
+        String string = TypeMapping.convert("String", column(String.class, String.class));
+        Boolean bool = TypeMapping.convert(Boolean.TRUE, column(Boolean.class, Boolean.class));
+
+        assertThat(string).isEqualTo("String");
+        assertThat(bool).isTrue();
+    }
+
+    @Test
+    public void should_handle_null_values() {
+        String string = TypeMapping.convert(null, column(String.class, String.class));
+
+        assertThat(string).isNull();
+    }
+
+    @Test
+    public void should_recover_from_NPE_in_mapping() {
+        TypeMapping.register(Character.class, String.class, Object::toString);
+        String string = TypeMapping.convert(null, column(Character.class, String.class));
+
+        assertThat(string).isNull();
+    }
+
+    @Test
+    public void should_try_mapper_if_value_is_null() {
+        TypeMapping.register(Character.class, String.class, (ch) -> ch == null ? "NULL" : ch.toString());
+        String string = TypeMapping.convert(null, column(Character.class, String.class));
+
+        assertThat(string).isEqualTo("NULL");
+    }
+
+    @Test
+    public void default_mappers() {
+        LocalDate dateNow = LocalDate.now();
+        LocalTime timeNow = LocalTime.now().withNano(0); // nanoes not supported in java.sql.Time
+        LocalDateTime datetimeNow = LocalDateTime.now();
+        ZonedDateTime zoneddatetimeNow = datetimeNow.atZone(ZoneId.systemDefault());
+
+        LocalDate date = TypeMapping.convert(Date.valueOf(dateNow), column(Date.class, LocalDate.class));
+        LocalTime time = TypeMapping.convert(Time.valueOf(timeNow), column(Time.class, LocalTime.class));
+        LocalDateTime localdatetime = TypeMapping.convert(Timestamp.valueOf(datetimeNow), column(Timestamp.class, LocalDateTime.class));
+        ZonedDateTime zoneddatetime = TypeMapping.convert(Timestamp.valueOf(datetimeNow), column(Timestamp.class, ZonedDateTime.class));
+
+        Boolean numberBool = TypeMapping.convert(0, column(Integer.class, Boolean.class));
+        Boolean numberBool2 = TypeMapping.convert(1, column(Integer.class, Boolean.class));
+        Boolean strBool = TypeMapping.convert("N", column(String.class, Boolean.class));
+        Boolean strBool2 = TypeMapping.convert("J", column(String.class, Boolean.class));
+        Boolean strBool3 = TypeMapping.convert("true", column(String.class, Boolean.class));
+        Boolean strBool4 = TypeMapping.convert("false", column(String.class, Boolean.class));
+
+        assertThat(dateNow.isEqual(date)).isTrue();
+        assertThat(timeNow.equals(time)).isTrue();
+        assertThat(datetimeNow.isEqual(localdatetime)).isTrue();
+        assertThat(zoneddatetimeNow.isEqual(zoneddatetime)).isTrue();
+
+        assertThat(numberBool).isFalse();
+        assertThat(numberBool2).isTrue();
+        assertThat(strBool).isFalse();
+        assertThat(strBool2).isTrue();
+        assertThat(strBool3).isTrue();
+        assertThat(strBool4).isFalse();
+    }
+}

--- a/jdbc/src/test/java/no/nav/sbl/sql/mapping/ValueMappingTest.java
+++ b/jdbc/src/test/java/no/nav/sbl/sql/mapping/ValueMappingTest.java
@@ -1,0 +1,26 @@
+package no.nav.sbl.sql.mapping;
+
+import org.junit.Test;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import static no.nav.sbl.sql.mapping.QueryMappingTest.column;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ValueMappingTest {
+    @Test
+    public void should_handle_common_resultset_type() throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        ValueMapping.getValue(column(String.class, null), rs);
+
+        verify(rs).getString("name");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void should_throw_exception_on_unknown_types() {
+        ValueMapping.getValue(column(List.class, null), null);
+    }
+}

--- a/jdbc/src/test/java/no/nav/sbl/sql/where/WhereClauseTest.java
+++ b/jdbc/src/test/java/no/nav/sbl/sql/where/WhereClauseTest.java
@@ -2,7 +2,7 @@ package no.nav.sbl.sql.where;
 
 import org.junit.Test;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class WhereClauseTest {

--- a/jdbc/src/test/java/no/nav/sbl/sql/where/WhereInTest.java
+++ b/jdbc/src/test/java/no/nav/sbl/sql/where/WhereInTest.java
@@ -5,7 +5,7 @@ package no.nav.sbl.sql.where;
 import org.junit.Test;
 
 import static java.util.Arrays.asList;
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class WhereInTest {
 


### PR DESCRIPTION
```java
// Data-objekt man er ute etter
@Value
class UserRecord implements SqlRecord {
    static {
        QueryMapping.register(String.class, Id.class, Id::new); // hvis det er behov for custom mapping
    }
    Column<String, Id> id;
    Column<String, String> name;
    Column<Integer, Integer> age;
    Column<Date, LocalDate> birth;
}

// Bruk
List<UserRecord> users = SqlUtils.select(jdbcTemplate, "user", UserRecord.class)
    .where(WhereClause.isNotNull("name"))
    .limit(10)
    .executeToList();
```
Lombok er ikke nødvendig, men det forventes at klassen har en konstruktør tilsvarende det man får med `@AllArgsConstructor` derifra. 

Konvertering fra sql-typer til domene-typer (e.g `java.sql.Time` til `java.time.Time`) gjøres automatisk. Egendefinerte konvertertinger kan legges til via `QueryMapping.register(fromCls, toCls, mapper);`

For feltet `birth` i eksemplet vil flyten være som følgende;
1. Når `SqlUtils.select` kalles vil `query.column("birth");` bli kalt.
2. En RowMapper vil bli laget med følge; 
    1. `sqlValue = rs.getDate("birth"); // mapping in ValueMapping` 
    2. `value = sqlValue.toLocalDate(); // mapping in TypeMapping`
    3. `column = Column.of(value)`
    4. Da alle kolonner er ferdig kalles konstruktøren til klassen.
