### PR TITLE
Justering av loggnivå ved forsøk på å hente brukerinfo på utløpte SAML-tokens

### DIFF
--- a/auth-openam-sbs/src/test/java/no/nav/common/auth/openam/sbs/OpenAMUserInfoServiceTest.java
+++ b/auth-openam-sbs/src/test/java/no/nav/common/auth/openam/sbs/OpenAMUserInfoServiceTest.java
@@ -1,5 +1,10 @@
 package no.nav.common.auth.openam.sbs;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import no.nav.brukerdialog.security.domain.IdentType;
@@ -8,6 +13,8 @@ import no.nav.common.auth.Subject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -19,7 +26,8 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static no.nav.common.auth.SsoToken.Type.EKSTERN_OPENAM;
 import static no.nav.common.auth.openam.sbs.OpenAMUserInfoService.BASE_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
-
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class OpenAMUserInfoServiceTest {
     private String contentType = "Content-Type";
@@ -29,12 +37,51 @@ public class OpenAMUserInfoServiceTest {
 
     private WireMockConfiguration wireMockConfig = wireMockConfig().port(8000);// No-args constructor defaults to port 8080
 
+    private Logger targetClassLogger = (Logger) LoggerFactory.getLogger(OpenAMUserInfoService.class);
+    private Appender<ILoggingEvent> mockedLogAppender = mock(Appender.class);
+
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(wireMockConfig);
 
     @Before
     public void setUp() throws Exception {
         service = new OpenAMUserInfoService(URI.create("http://localhost:8000" + BASE_PATH));
+    }
+
+    @Test
+    public void getUserInfo__invalid_session_because_of_expired_token() {
+        beginLogCapture();
+
+        String body = "{\"exception\":{\"message\":\"Invalid session ID.AQIC5wM2LY4Sfcy4eCp3R5V0YrY__qcn459QF4e2q2MesPA.*AAJTSQACMDIAAlMxAAIwMQ..*\",\"name\":\"com.sun.identity.idsvcs.TokenExpired\"}}";
+        stubFor(get(urlMatching(BASE_PATH + ".*"))
+                .willReturn(aResponse()
+                        .withHeader(contentType, json)
+                        .withStatus(401)
+                        .withBody(body)));
+
+        Optional<Subject> validtoken = service.convertTokenToSubject("sso-token");
+        assertThat(validtoken).isEmpty();
+
+        verifyLevelOfSingleLogEvent(Level.INFO);
+        endLogCapture();
+    }
+
+    @Test
+    public void getUserInfo__unknown_error() {
+        beginLogCapture();
+
+        String body = "{Internal Server Error}";
+        stubFor(get(urlMatching(BASE_PATH + ".*"))
+                .willReturn(aResponse()
+                        .withHeader(contentType, json)
+                        .withStatus(500)
+                        .withBody(body)));
+
+        Optional<Subject> validtoken = service.convertTokenToSubject("sso-token");
+        assertThat(validtoken).isEmpty();
+
+        verifyLevelOfSingleLogEvent(Level.ERROR);
+        endLogCapture();
     }
 
     @Test
@@ -100,6 +147,20 @@ public class OpenAMUserInfoServiceTest {
         Optional<Subject> userInfo = service.convertTokenToSubject("sso-token");
 
         assertThat(userInfo).isEmpty();
+    }
+
+    private void beginLogCapture() {
+        targetClassLogger.addAppender(mockedLogAppender);
+    }
+
+    private void endLogCapture() {
+        targetClassLogger.detachAppender(mockedLogAppender);
+    }
+
+    private void verifyLevelOfSingleLogEvent(Level error) {
+        ArgumentCaptor<LoggingEvent> loggingEventCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+        verify(mockedLogAppender).doAppend(loggingEventCaptor.capture());
+        assertThat(loggingEventCaptor.getValue().getLevel()).isEqualTo(error);
     }
 
 }


### PR DESCRIPTION
Etter at vi gikk live med den nye innloggingslinjen, innloggingslinje-api, så får vi i overkant av 1000 logginnslag/time på error-nivå pga forsøk på å hente ut brukerinfo på utløpte SAML-tokens. Slik som dette:

`Could not get user attributes from OpenAM. HTTP status: 401 Unauthorized. Response:{"exception":{"message":"Invalid session ID.<her logges hele tokenet>","name":"com.sun.identity.idsvcs.TokenExpired"}}`

*Bakgrunn*
Den uinnloggede delen av nav.no gjør kall mot Innloggingslinje-api, og dette er typisk brukere som da ikke er innlogget men de kan ha nav-esso-cookies med utløpte tokens. Dermed vil Innloggingslinje-api sitt OpenAMFilter gjøre kall mot OpenAM for å hente ut info om brukeren, dette feiler fordi token-et har utløpt. Disse feilene logges da som error, selv om dette ikke er en error sett fra Innloggingslinje-api sin side.

*Løsningsforslag*
1. Senke loggnivået for innslag hvor sesjonen er ugyldig pga utløpt token, og logge dette som f.eks. info. Alle andre feiltyper kan logges som error slik som før. 
2. OpenAM-filteret må kun forsøke å hente ut info om brukere som man vet at har et gyldig token. Dette vil medføre et ekstra kall mot OpenAM, fordi man da først må gjøre et kall mot OpenAM for å sjekke om tokenet er gyldig, hvis det er det så må det gjøres et nytt kall for å hente ut brukerinfoen.

*Valgt løsning i denne pull-request-en*
Har her gått for løsning nummer 1, fordi det er det som gir færrest forespørsler mot OpenAM.

**Er det andre bedre måter å løse dette problemet?**

Jira-oppgave: IN-648. Fjerne misvisende errorlogging fra Innloggingslinje-api