### PR TITLE
Removed configuration for setting the global log level to INFO...

### DIFF
--- a/api-app/src/main/java/no/nav/apiapp/ApiAppServletContextListener.java
+++ b/api-app/src/main/java/no/nav/apiapp/ApiAppServletContextListener.java
@@ -118,12 +118,6 @@ public class ApiAppServletContextListener implements WebApplicationInitializer, 
 
     private final Konfigurator konfigurator;
 
-    static {
-        if (isEnvironmentClass(T)) {
-            setGlobalLogLevel(INFO);
-        }
-    }
-
     // på jboss
     public ApiAppServletContextListener() {
         this(null);


### PR DESCRIPTION
.. for all logs in environmentclass t

This was previously set for ease of debugging, probably not needed anymore.