### PR TITLE
added support for custom error handling in OpenAMUserInfoService

### DIFF
--- a/auth-openam-sbs/src/main/java/no/nav/common/auth/openam/sbs/OpenAMEventListener.java
+++ b/auth-openam-sbs/src/main/java/no/nav/common/auth/openam/sbs/OpenAMEventListener.java
@@ -1,0 +1,31 @@
+package no.nav.common.auth.openam.sbs;
+
+import lombok.Builder;
+import lombok.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public interface OpenAMEventListener {
+
+    Logger LOG = LoggerFactory.getLogger(OpenAMEventListener.class);
+    String OPENAM_GENERAL_ERROR = "Could not get user attributes from OpenAM. ";
+
+    default void fetchingUserAttributesFailed(OpenAmResponse openAmResponse) {
+        LOG.error("{}: {}", OPENAM_GENERAL_ERROR, openAmResponse);
+    }
+
+    default void missingUserAttribute(String attribute) {
+        LOG.error("{}: Response did not contain attribute: {}", OPENAM_GENERAL_ERROR, attribute);
+    }
+
+    @Value
+    @Builder
+    class OpenAmResponse {
+        public final int status;
+        public final String phrase;
+        public final String content;
+    }
+
+    class DefaultOpenAMEventListener implements OpenAMEventListener {
+    }
+}

--- a/auth-openam-sbs/src/main/java/no/nav/common/auth/openam/sbs/OpenAMUserInfoService.java
+++ b/auth-openam-sbs/src/main/java/no/nav/common/auth/openam/sbs/OpenAMUserInfoService.java
@@ -5,8 +5,6 @@ import no.nav.common.auth.SsoToken;
 import no.nav.common.auth.Subject;
 import no.nav.sbl.rest.RestUtils;
 import no.nav.sbl.util.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
@@ -26,17 +24,15 @@ import static no.nav.sbl.util.StringUtils.of;
 
 public class OpenAMUserInfoService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(OpenAMUserInfoService.class);
-
     public static final String PARAMETER_UID = "uid";
     public static final String PARAMETER_SECURITY_LEVEL = "SecurityLevel";
 
-    private static final String OPENAM_GENERAL_ERROR = "Could not get user attributes from OpenAM. ";
     public static final String BASE_PATH = "/identity/json/attributes";
 
     private final URI endpointURL;
     private final Client client = RestUtils.createClient(DEFAULT_CONFIG.withDisableParameterLogging(true));
     private final List<String> subjectAttributes;
+    private final OpenAMEventListener openAMEventListener;
 
     @Deprecated
     public OpenAMUserInfoService(URI endpointURL) {
@@ -44,6 +40,7 @@ public class OpenAMUserInfoService {
     }
 
     public OpenAMUserInfoService(OpenAmConfig openAmConfig) {
+        this.openAMEventListener = openAmConfig.openAMEventListener;
         this.endpointURL = resolveEndpointURL(openAmConfig);
         this.subjectAttributes = subjectAttributes(openAmConfig);
     }
@@ -70,7 +67,7 @@ public class OpenAMUserInfoService {
     }
 
     public Optional<Map<String, String>> getUserInfo(String token, List<String> attributes) {
-        return of(token).flatMap(t -> checkResponse(requestUserAttributes(t, attributes)).map(this::attributesToMap));
+        return of(token).flatMap(t -> checkResponse(requestUserAttributes(t, attributes), token).map(this::attributesToMap));
     }
 
     public Response requestUserAttributes(String token) {
@@ -81,20 +78,25 @@ public class OpenAMUserInfoService {
         return client.target(getUrl(token, attributes)).request().get();
     }
 
-    private Optional<OpenAMAttributes> checkResponse(Response response) {
+    private Optional<OpenAMAttributes> checkResponse(Response response, String sessionId) {
         int status = response.getStatus();
         if (status < 399) {
             return of(response.readEntity(OpenAMAttributes.class));
         } else {
             String payload = response.readEntity(String.class);
             String phrase = response.getStatusInfo().getReasonPhrase();
-            String message = OPENAM_GENERAL_ERROR + "HTTP status: " + status + " " + phrase + ".";
-            if (status == 401) {
-                message += " Response:" + payload;
-            }
-            LOG.error(message);
+            openAMEventListener.fetchingUserAttributesFailed(OpenAMEventListener.OpenAmResponse.builder()
+                    .status(status)
+                    .phrase(phrase)
+                    .content(sanitize(payload, sessionId))
+                    .build()
+            );
             return empty();
         }
+    }
+
+    private String sanitize(String payload, String sessionId) {
+        return payload.replaceAll(sessionId, "<session id removed>");
     }
 
     public String getUrl(String token) {
@@ -121,7 +123,7 @@ public class OpenAMUserInfoService {
             String uid = attributeMap.get(PARAMETER_UID);
             return of(new Subject(uid, IdentType.EksternBruker, SsoToken.eksternOpenAM(token, attributeMap)));
         } else {
-            LOG.error(OPENAM_GENERAL_ERROR + "Response did not contain attribute " + PARAMETER_UID);
+            openAMEventListener.missingUserAttribute(PARAMETER_UID);
             return empty();
         }
     }

--- a/auth-openam-sbs/src/main/java/no/nav/common/auth/openam/sbs/OpenAmConfig.java
+++ b/auth-openam-sbs/src/main/java/no/nav/common/auth/openam/sbs/OpenAmConfig.java
@@ -4,10 +4,7 @@ import lombok.Builder;
 import lombok.Value;
 import no.nav.sbl.util.EnvironmentUtils;
 
-import java.util.Collections;
 import java.util.List;
-
-import static no.nav.common.auth.openam.sbs.OpenAMUserInfoService.PARAMETER_UID;
 
 @Value
 @Builder(toBuilder = true)
@@ -18,6 +15,8 @@ public class OpenAmConfig {
 
     public String restUrl;
     public List<String> additionalAttributes;
+    @Builder.Default
+    public OpenAMEventListener openAMEventListener = new OpenAMEventListener.DefaultOpenAMEventListener();
 
     public static OpenAmConfig fromSystemProperties() {
         return OpenAmConfig.builder()


### PR DESCRIPTION
 - a custom OpenAMEventListener can now be implemented
 - the raw response content from openam is sanitized to prevent logging of session ids