### PR TITLE
BREAKING: Set reuseForks=true in mor-pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -452,11 +452,27 @@
                     <argLine>${jacoco.agent.argLine} -Xmx2g</argLine>
 
                     <!--
-                     maven-surefire default er forkCount=1 + reuseForks=true
-                     dvs at surefire vil kjøre alle testene i en og samme jvm pr maven-modul
+                    Å sette `reuseFork` til `true` vil føre til at surefire fyrer opp en separat JVM for hver
+                    eneste testklasse.
+
+                    Dette fører til ekstremt treg eksekvering av tester (i ett tilfelle 4-5 min kontra
+                    20-30 sekunder om satt til `false`)
+
+                    Merk at å sette denne til `true` krever at man skriver tester som er godt isolerte fra hverandre.
+                    F.eks. kan det føre til problemer å sette statiske eller globale felter i klasser
+                    som gjenbrukes på tvers av testmetoder. Sørg for å lage en ny instanse av slike felter for hver
+                    testmetode ved bruk av @BeforeEach (JUnit 5) eller lignende for å unngå tilstandsfulle testklasser.
+
+                    Se følgende link for flere detaljer:
+
+                    https://maven.apache.org/surefire/maven-surefire-plugin/examples/ fork-options-and-parallel-execution.html
+
                     -->
-                    <reuseForks>false
-                    </reuseForks> <!-- fører til at hver test-klasse kjøres i egen jvm. Dermed oppnår vi bedre isolasjon mellom potensielt skjøre tester, som kan finne på å mutere på global state etc -->
+                    <reuseForks>true</reuseForks>
+
+                    <forkCount>1C</forkCount> <!-- fyr opp 1 JVM per cpu-kjerne -->
+
+                    <argLine>-Xmx1024m</argLine> <!-- Gi nok minne for å unngå terminerende JVM-er -->
 
                     <!-- fjerner edge-caser ved nøstede classloadere, som f.eks. hvis man tester med jetty -->
                     <useSystemClassLoader>false</useSystemClassLoader>


### PR DESCRIPTION
Note that this may break tests that are not
properly isolated. Avoid using class fields
that are reused between test methods. Make sure
to create new instances of such fields using
@BeforeEach (JUnit5) or similar.