### PR TITLE
Fix/azuresubject

### DIFF
--- a/oidc-security/src/main/java/no/nav/brukerdialog/security/jaspic/OidcAuthModule.java
+++ b/oidc-security/src/main/java/no/nav/brukerdialog/security/jaspic/OidcAuthModule.java
@@ -24,8 +24,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
+import static java.util.Optional.*;
 import static no.nav.brukerdialog.security.Constants.*;
 import static no.nav.brukerdialog.security.jwks.CacheMissAction.NO_REFRESH;
 import static no.nav.brukerdialog.security.jwks.CacheMissAction.REFRESH;
@@ -36,6 +35,7 @@ public class OidcAuthModule implements LoginProvider {
 
     private static final Logger log = LoggerFactory.getLogger(OidcAuthModule.class);
     private static final boolean sslOnlyCookies = !Boolean.valueOf(System.getProperty("develop-local", "false"));
+    public static final String AZURE_AD_CLAIM = "NAVident";
 
     private final List<OidcProvider> providers;
     private final OidcTokenValidator oidcTokenValidator;
@@ -94,13 +94,13 @@ public class OidcAuthModule implements LoginProvider {
                 OidcTokenValidatorResult refreshedTokenValidatorResult = oidcTokenValidator.validate(refreshedToken, oidcProvider, cacheMissAction);
                 if (refreshedTokenValidatorResult.isValid()) {
                     addHttpOnlyCookie(httpServletRequest, httpServletResponse, ID_TOKEN_COOKIE_NAME, refreshedToken);
-                    return handleValidatedToken(refreshedTokenValidatorResult, refreshedToken, refreshedTokenValidatorResult.getSubject(), oidcProvider);
+                    return handleValidatedToken(refreshedTokenValidatorResult, refreshedToken, oidcProvider);
                 }
             }
         }
 
         if (requestTokenValidatorResult.isValid()) {
-            return handleValidatedToken(requestTokenValidatorResult, requestToken, requestTokenValidatorResult.getSubject(), oidcProvider);
+            return handleValidatedToken(requestTokenValidatorResult, requestToken, oidcProvider);
         }
         return Stream.empty();
     }
@@ -172,8 +172,12 @@ public class OidcAuthModule implements LoginProvider {
                 : req.getRequestURL().toString() + "?" + req.getQueryString();
     }
 
-    private Stream<Subject> handleValidatedToken(OidcTokenValidatorResult requestTokenValidatorResult, String token, String username, OidcProvider oidcProvider) {
+    private Stream<Subject> handleValidatedToken(OidcTokenValidatorResult requestTokenValidatorResult, String token, OidcProvider oidcProvider) {
         SsoToken ssoToken = SsoToken.oidcToken(token, requestTokenValidatorResult.getAttributes());
+        String username = ofNullable(requestTokenValidatorResult.getAttributes().get(AZURE_AD_CLAIM))
+                .map((object) -> (String)object)
+                .orElseGet(requestTokenValidatorResult::getSubject);
+
         Subject subject = new Subject(username, oidcProvider.getIdentType(token), ssoToken);
         return Stream.of(subject);
     }

--- a/oidc-security/src/test/java/no/nav/brukerdialog/security/jaspic/OidcAuthModuleTest.java
+++ b/oidc-security/src/test/java/no/nav/brukerdialog/security/jaspic/OidcAuthModuleTest.java
@@ -18,6 +18,9 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import java.util.Map;
+import java.util.UUID;
+
 import static java.util.Arrays.asList;
 import static java.util.Optional.of;
 import static no.nav.brukerdialog.security.jwks.CacheMissAction.NO_REFRESH;
@@ -54,6 +57,14 @@ public class OidcAuthModuleTest {
     @Test
     public void authenticate__matching_token__returns_subject() {
         Subject subject = testSubject("token3");
+        mockValidSubjectForProvider(subject, provider3, NO_REFRESH);
+
+        assertThat(oidcAuthModule.authenticate(httpServletRequest, httpServletResponse)).hasValue(subject);
+    }
+
+    @Test
+    public void authenticate__matching_token__returns_subject_azure_ad() {
+        Subject subject = testSubjectAzureAD("token3");
         mockValidSubjectForProvider(subject, provider3, NO_REFRESH);
 
         assertThat(oidcAuthModule.authenticate(httpServletRequest, httpServletResponse)).hasValue(subject);
@@ -106,6 +117,21 @@ public class OidcAuthModuleTest {
         String uid = "test-subject";
         JwtClaims jwtClaims = new JwtClaims();
         jwtClaims.setSubject(uid);
+        jwtClaims.setExpirationTimeMinutesInTheFuture(600);
+        return TestSubjectUtils.builder()
+                .uid(uid)
+                .identType(IDENT_TYPE)
+                .token(token)
+                .tokenType(OIDC)
+                .attributes(jwtClaims.getClaimsMap())
+                .build();
+    }
+
+    private Subject testSubjectAzureAD(String token) {
+        String uid = "test-subject";
+        JwtClaims jwtClaims = new JwtClaims();
+        jwtClaims.setSubject(UUID.randomUUID().toString());
+        jwtClaims.setClaim("NAVident", uid);
         jwtClaims.setExpirationTimeMinutesInTheFuture(600);
         return TestSubjectUtils.builder()
                 .uid(uid)


### PR DESCRIPTION
Leser ut subject fra custom-claim `NAVident` om det finnes, hvis ikke så defaulter man tilbake til dagens-løsning og leder fra `sub`