### PR TITLE
la til stotte for lesing av templated yaml-filer

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -86,6 +86,7 @@
         <vavr.version>0.9.0</vavr.version>
         <nocommons.version>0.6</nocommons.version>
         <shedlock.version>0.18.2</shedlock.version>
+        <handlebars.version>4.1.2</handlebars.version>
         <!--
           obs:
            aspectj settes i dependencyManagement i modig-security sin modig-main parent. (n� 1.7.4)
@@ -787,6 +788,11 @@
                         <groupId>commons-logging</groupId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.github.jknack</groupId>
+                <artifactId>handlebars</artifactId>
+                <version>${handlebars.version}</version>
             </dependency>
 
             <!-- javax -->

--- a/nais/pom.xml
+++ b/nais/pom.xml
@@ -32,6 +32,10 @@
             <groupId>no.nav.common</groupId>
             <artifactId>yaml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.jknack</groupId>
+            <artifactId>handlebars</artifactId>
+        </dependency>
 
         <!-- logging -->
         <dependency>

--- a/nais/src/main/java/no/nav/common/nais/utils/NaisYamlUtils.java
+++ b/nais/src/main/java/no/nav/common/nais/utils/NaisYamlUtils.java
@@ -1,5 +1,8 @@
 package no.nav.common.nais.utils;
 
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
+import lombok.SneakyThrows;
 import no.nav.common.yaml.YamlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,6 +125,14 @@ public class NaisYamlUtils {
 
     public static NaiseratorSpec getConfig(String path) {
         String content = NaisUtils.getFileContent(path);
+        return YamlUtils.fromYaml(content, NaiseratorSpec.class);
+    }
+
+    @SneakyThrows
+    public static NaiseratorSpec getTemplatedConfig(String path, Object vars) {
+        Handlebars handlebars = new Handlebars();
+        Template template = handlebars.compileInline(NaisUtils.getFileContent(path));
+        String content = template.apply(vars);
         return YamlUtils.fromYaml(content, NaiseratorSpec.class);
     }
 

--- a/nais/src/test/resources/min-nais-templated-example.yaml
+++ b/nais/src/test/resources/min-nais-templated-example.yaml
@@ -1,0 +1,26 @@
+apiVersion: "nais.io/v1alpha1"
+kind: "Application"
+metadata:
+  name: nais-testapp
+  {{#if namespace}}
+  namespace: {{namespace}}
+  {{else}}
+  namespace: default
+  {{/if}}
+  labels:
+    team: aura
+spec:
+  image: {{image}}
+  {{#if ingresses}}
+  ingresses:
+    {{#each ingresses}}
+    - {{this}}
+    {{/each}}
+  {{/if}}
+  {{#if env}}
+  env:
+    {{#each env}}
+    - name: {{@key}}
+      value: "{{this}}"
+    {{/each}}
+  {{/if}}


### PR DESCRIPTION
deploy-cli bruker "VAR" og "VARS" for injecting av variabler fra byggejobben.
For å starte appen lokalt kan det være kjekt å gjenbruke denne templatingen. 