### PR TITLE
La til mulighet for å sende inn config for validering med Azure AD

### DIFF
--- a/api-app/src/main/java/no/nav/apiapp/config/ApiAppConfigurator.java
+++ b/api-app/src/main/java/no/nav/apiapp/config/ApiAppConfigurator.java
@@ -53,6 +53,8 @@ public interface ApiAppConfigurator {
 
     ApiAppConfigurator validateAzureAdInternalUsersTokens();
 
+    ApiAppConfigurator validateAzureAdInternalUsersTokens(AzureADB2CConfig config);
+
     ApiAppConfigurator securityTokenServiceLogin();
     ApiAppConfigurator securityTokenServiceLogin(SecurityTokenServiceOidcProviderConfig securityTokenServiceOidcProviderConfig);
     ApiAppConfigurator oidcProvider(OidcProvider oidcProvider);

--- a/api-app/src/main/java/no/nav/apiapp/config/Konfigurator.java
+++ b/api-app/src/main/java/no/nav/apiapp/config/Konfigurator.java
@@ -172,6 +172,11 @@ public class Konfigurator implements ApiAppConfigurator {
     }
 
     @Override
+    public ApiAppConfigurator validateAzureAdInternalUsersTokens(AzureADB2CConfig config) {
+        return oidcProvider(new InternalUserLoginProvider(config));
+    }
+
+    @Override
     public ApiAppConfigurator securityTokenServiceLogin() {
         return securityTokenServiceLogin(SecurityTokenServiceOidcProviderConfig.readFromSystemProperties());
     }


### PR DESCRIPTION
Kunne brukt `azureADB2CLogin(AzureADB2CConfig azureADB2CConfig)` også, men den står som deprecated.