### PR TITLE
Disabled selftester burde ikke påvirke aggregertstatus

### DIFF
--- a/selftest/src/main/java/no/nav/sbl/dialogarena/common/web/selftest/domain/SelftestResult.java
+++ b/selftest/src/main/java/no/nav/sbl/dialogarena/common/web/selftest/domain/SelftestResult.java
@@ -25,7 +25,8 @@ public class SelftestResult {
     }
 
     public boolean harFeil() {
-        return this.getResult() != SelfTestStatus.OK;
+        SelfTestStatus result = getResult();
+        return result != SelfTestStatus.OK && result != SelfTestStatus.DISABLED;
     }
 
 }

--- a/selftest/src/test/java/no/nav/sbl/dialogarena/common/web/selftest/domain/SelftestResultTest.java
+++ b/selftest/src/test/java/no/nav/sbl/dialogarena/common/web/selftest/domain/SelftestResultTest.java
@@ -13,4 +13,28 @@ public class SelftestResultTest {
         assertThat(selftestResult.getResult()).isEqualTo(SelfTestStatus.ERROR);
     }
 
+    @Test
+    public void harFeil__ok_er_ikke_feil(){
+        SelftestResult selftestResult = SelftestResult.builder().result(SelfTestStatus.OK).build();
+        assertThat(selftestResult.harFeil()).isFalse();
+    }
+
+    @Test
+    public void harFeil__warning_er_feil(){
+        SelftestResult selftestResult = SelftestResult.builder().result(SelfTestStatus.WARNING).build();
+        assertThat(selftestResult.harFeil()).isTrue();
+    }
+
+    @Test
+    public void harFeil__disabled_er_ikke_feil(){
+        SelftestResult selftestResult = SelftestResult.builder().result(SelfTestStatus.DISABLED).build();
+        assertThat(selftestResult.harFeil()).isFalse();
+    }
+
+    @Test
+    public void harFeil__error_er_feil(){
+        SelftestResult selftestResult = SelftestResult.builder().result(SelfTestStatus.ERROR).build();
+        assertThat(selftestResult.harFeil()).isTrue();
+    }
+
 }


### PR DESCRIPTION
Noen som evt husker noe om hvorfor `DISABLED` skulle føre til `WARNING` status for hele selftesten?