### PR TITLE
Legg til avhengighet til saaj-impl i cxf modul

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -509,6 +509,11 @@
                 <version>${cxf-core.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.sun.xml.messaging.saaj</groupId>
+                <artifactId>saaj-impl</artifactId>
+                <version>1.5.2</version>
+            </dependency>
+            <dependency>
                 <!-- NB:
                 transitive dependency through opensaml, manually upgraded to prevent https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-32236
                 -->

--- a/cxf/pom.xml
+++ b/cxf/pom.xml
@@ -65,6 +65,14 @@
 			<artifactId>cxf-rt-transports-http</artifactId>
 		</dependency>
         <dependency>
+            <!--
+                Transitiv avhengighet fra org.apache.cxf:cxf-core. Må legges til eksplisitt for Java 9+ for å unngå
+                class not found exception.
+             -->
+            <groupId>com.sun.xml.messaging.saaj</groupId>
+            <artifactId>saaj-impl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>${jsoup.version}</version>


### PR DESCRIPTION
For å rette feil: Unable to create SAAJ meta-factory: Provider com.sun.xml.internal.messaging.saaj.soap.SAAJMetaFactoryImpl not found