### PR TITLE
Oidc auth

### DIFF
--- a/auth/src/main/java/no/nav/common/auth/oidc/filter/OidcAuthenticationFilter.java
+++ b/auth/src/main/java/no/nav/common/auth/oidc/filter/OidcAuthenticationFilter.java
@@ -58,7 +58,7 @@ public class OidcAuthenticationFilter implements Filter {
                     JWT jwtToken = JWTParser.parse(token.get());
 
                     // Skip this authenticator if the audience is not matching
-                    if (!hasMatchingAudience(jwtToken, authenticator.config.clientId)) {
+                    if (!hasMatchingAudience(jwtToken, authenticator.config.clientIds)) {
                         continue;
                     }
 

--- a/auth/src/main/java/no/nav/common/auth/oidc/filter/OidcAuthenticator.java
+++ b/auth/src/main/java/no/nav/common/auth/oidc/filter/OidcAuthenticator.java
@@ -22,7 +22,7 @@ public class OidcAuthenticator {
             throw new IllegalStateException("OidcAuthenticatorConfig is missing one or more values");
         }
 
-        OidcTokenValidator validator = new OidcTokenValidator(config.discoveryUrl, config.clientId);
+        OidcTokenValidator validator = new OidcTokenValidator(config.discoveryUrl, config.clientIds);
         return new OidcAuthenticator(validator, config);
     }
 

--- a/auth/src/main/java/no/nav/common/auth/oidc/filter/OidcAuthenticatorConfig.java
+++ b/auth/src/main/java/no/nav/common/auth/oidc/filter/OidcAuthenticatorConfig.java
@@ -7,6 +7,9 @@ import no.nav.common.auth.subject.IdentType;
 import no.nav.common.auth.utils.AuthHeaderTokenFinder;
 import no.nav.common.auth.utils.TokenFinder;
 
+import java.util.Collections;
+import java.util.List;
+
 @Wither
 @NoArgsConstructor
 @AllArgsConstructor
@@ -15,8 +18,8 @@ public class OidcAuthenticatorConfig {
     // OIDC discovery URL
     public String discoveryUrl;
 
-    // Client ID / Audience
-    public String clientId;
+    // Is used to validate the audience claim (if the token has multiple audiences and the AZP claim is set, then AZP will also be validated against this list of IDs)
+    public List<String> clientIds;
 
     // What type of user is being authenticated
     public IdentType identType;
@@ -37,8 +40,14 @@ public class OidcAuthenticatorConfig {
 
     public boolean isValid() {
         return discoveryUrl != null
-                && clientId != null
+                && clientIds != null
                 && identType != null
                 && idTokenFinder != null;
     }
+
+    public OidcAuthenticatorConfig withClientId(String clientId) {
+        this.clientIds = Collections.singletonList(clientId);
+        return this;
+    }
+
 }

--- a/auth/src/main/java/no/nav/common/auth/utils/ServiceUserTokenFinder.java
+++ b/auth/src/main/java/no/nav/common/auth/utils/ServiceUserTokenFinder.java
@@ -1,0 +1,40 @@
+package no.nav.common.auth.utils;
+
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTParser;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.servlet.http.HttpServletRequest;
+import java.text.ParseException;
+import java.util.Optional;
+
+/**
+ * Denne token finderen henter tokens ut fra Authorization header og sjekker at subject er en systembruker.
+ * Denne finderen er kun tenkt å brukes for å validere systembruker tokens fra OpenAM siden de ikke kan skilles på en annen måte.
+ */
+@Slf4j
+public class ServiceUserTokenFinder implements TokenFinder {
+
+    @Override
+    public Optional<String> findToken(HttpServletRequest request) {
+        Optional<String> maybeToken = TokenUtils.getTokenFromHeader(request);
+
+        if (maybeToken.isPresent()) {
+            try {
+                JWT jwt = JWTParser.parse(maybeToken.get());
+                String subject = jwt.getJWTClaimsSet().getSubject();
+
+                if (subject.startsWith("srv")) {
+                    return maybeToken;
+                } else {
+                    log.warn("ServiceUserTokenFinder found token with invalid subject " + subject);
+                }
+            } catch (ParseException e) {
+                log.error("Failed to parse token", e);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+}

--- a/auth/src/main/java/no/nav/common/auth/utils/TokenUtils.java
+++ b/auth/src/main/java/no/nav/common/auth/utils/TokenUtils.java
@@ -7,6 +7,7 @@ import no.nav.common.auth.subject.IdentType;
 import javax.servlet.http.HttpServletRequest;
 import java.text.ParseException;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 import static no.nav.common.auth.Constants.AAD_NAV_IDENT_CLAIM;
@@ -34,9 +35,11 @@ public class TokenUtils {
         return subject;
     }
 
-    public static boolean hasMatchingAudience(JWT jwtToken, String audience) {
+    public static boolean hasMatchingAudience(JWT jwtToken, List<String> audiences) {
         try {
-            return jwtToken.getJWTClaimsSet().getAudience().contains(audience);
+            // Checks if any of the audiences in the token matches any of the given audiences
+            List<String> tokenAudiences = jwtToken.getJWTClaimsSet().getAudience();
+            return tokenAudiences.stream().anyMatch(audiences::contains);
         } catch (ParseException e) {
             return false;
         }

--- a/auth/src/test/java/no/nav/common/auth/utils/ServiceUserTokenFinderTest.java
+++ b/auth/src/test/java/no/nav/common/auth/utils/ServiceUserTokenFinderTest.java
@@ -1,0 +1,63 @@
+package no.nav.common.auth.utils;
+
+import no.nav.common.auth.test_provider.JwtTestTokenIssuer;
+import no.nav.common.auth.test_provider.JwtTestTokenIssuerConfig;
+import no.nav.common.auth.test_provider.OidcProviderTestRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ServiceUserTokenFinderTest {
+
+    private final static String NAIS_STS_ID = "oidc-provider-test-rule-nais-sts";
+
+    private final static JwtTestTokenIssuerConfig naisStsIssuerConfig = JwtTestTokenIssuerConfig.builder()
+            .id(NAIS_STS_ID)
+            .issuer(NAIS_STS_ID)
+            .audience(NAIS_STS_ID)
+            .build();
+
+    @Rule
+    public OidcProviderTestRule naisStsOidcProviderRule = new OidcProviderTestRule(naisStsIssuerConfig);
+
+    @Test
+    public void should_return_token_for_service_user() {
+        String token = naisStsOidcProviderRule.getToken(new JwtTestTokenIssuer.Claims("srvveilarbtest"));
+
+        HttpServletRequest servletRequest = mock(HttpServletRequest.class);
+        when(servletRequest.getHeader("Authorization")).thenReturn("Bearer " + token);
+
+        Optional<String> maybeToken = new ServiceUserTokenFinder().findToken(servletRequest);
+
+        assertTrue(maybeToken.isPresent());
+    }
+
+    @Test
+    public void should_return_empty_for_non_service_user() {
+        String token = naisStsOidcProviderRule.getToken(new JwtTestTokenIssuer.Claims("some-user"));
+
+        HttpServletRequest servletRequest =  mock(HttpServletRequest.class);
+        when(servletRequest.getHeader("Authorization")).thenReturn("Bearer " + token);
+
+        Optional<String> maybeToken = new ServiceUserTokenFinder().findToken(servletRequest);
+
+        assertTrue(maybeToken.isEmpty());
+    }
+
+    @Test
+    public void should_return_empty_for_missing_auth_header() {
+        HttpServletRequest servletRequest =  mock(HttpServletRequest.class);
+        when(servletRequest.getHeader("Authorization")).thenReturn(null);
+
+        Optional<String> maybeToken = new ServiceUserTokenFinder().findToken(servletRequest);
+
+        assertTrue(maybeToken.isEmpty());
+    }
+
+}


### PR DESCRIPTION
La til støtte for å valider flere clientIDer med 1 auth config og ny token finder for Open AM systembruker tokens