### PR TITLE
Flyttet X509TrustManager til egen fil

### DIFF
--- a/test/src/main/java/no/nav/common/test/ssl/SSLTestUtils.java
+++ b/test/src/main/java/no/nav/common/test/ssl/SSLTestUtils.java
@@ -22,23 +22,7 @@ public class SSLTestUtils {
     @SneakyThrows
     private static SSLContext trustAllSSLContext() {
         SSLContext sslContext = SSLContext.getInstance("SSL");
-        sslContext.init(null, new TrustManager[]{
-                new X509TrustManager() {
-                    @Override
-                    public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
-
-                    }
-
-                    @Override
-                    public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
-                    }
-
-                    @Override
-                    public X509Certificate[] getAcceptedIssuers() {
-                        return null;
-                    }
-                }
-        }, new SecureRandom());
+        sslContext.init(null, new TrustManager[]{ new TrustAllX509TrustManager() }, new SecureRandom());
         return sslContext;
     }
 

--- a/test/src/main/java/no/nav/common/test/ssl/TrustAllX509TrustManager.java
+++ b/test/src/main/java/no/nav/common/test/ssl/TrustAllX509TrustManager.java
@@ -16,6 +16,6 @@ public class TrustAllX509TrustManager implements X509TrustManager {
 
     @Override
     public X509Certificate[] getAcceptedIssuers() {
-        return null;
+        return new X509Certificate[0];
     }
 }

--- a/test/src/main/java/no/nav/common/test/ssl/TrustAllX509TrustManager.java
+++ b/test/src/main/java/no/nav/common/test/ssl/TrustAllX509TrustManager.java
@@ -1,0 +1,21 @@
+package no.nav.common.test.ssl;
+
+import javax.net.ssl.X509TrustManager;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+public class TrustAllX509TrustManager implements X509TrustManager {
+    @Override
+    public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        return null;
+    }
+}


### PR DESCRIPTION
Gjør det lettere å sette OkHttp uten sertifikat validering, e.g;

```java
RestClient.setBaseClient(
  RestClient
  .baseClientBuilder()
  .sslSocketFactory(new TrustAllSSLSocketFactory(), new TrustAllX509TrustManager())
  .build()
);
```