### PR TITLE
La til driftsmelding med feilede komponenter i selftest HTML.

### DIFF
--- a/health/src/main/java/no/nav/common/health/selftest/SelftestHtmlGenerator.java
+++ b/health/src/main/java/no/nav/common/health/selftest/SelftestHtmlGenerator.java
@@ -31,11 +31,20 @@ public class SelftestHtmlGenerator {
                 .map(SelftestHtmlGenerator::lagTabellrad)
                 .collect(Collectors.toList());
 
+        List<String> feilendeKomponenter = checkResults
+                .stream()
+                .filter(cr -> cr.checkResult.isUnhealthy() && cr.selfTestCheck.isCritical())
+                .map(cr -> cr.selfTestCheck.getDescription().replaceAll(",", "."))
+                .collect(Collectors.toList());
+
         String html = htmlTemplate;
         html = html.replace("${aggregertStatus}", getStatusNavnElement(SelfTestUtils.aggregateStatus(checkResults), "span"));
         html = html.replace("${resultater}", String.join("\n", tabellrader));
         html = html.replace("${host}", "Host: " + host);
         html = html.replace("${generert-tidspunkt}", timestamp.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+
+        // SiteScope forventer å finne en tag med id="driftsMelding" som inneholder feilede komponenter
+        html = html.replace("${feilende-komponenter}", String.join(", ", feilendeKomponenter));
 
         return html;
     }

--- a/health/src/main/resources/selftest/SelfTestPage.html
+++ b/health/src/main/resources/selftest/SelfTestPage.html
@@ -83,6 +83,8 @@
 
 <h5>Siden generert: ${generert-tidspunkt}</h5>
 
+<h6 id="driftMelding">${feilende-komponenter}</h6>
+
 </body>
 
 </html>

--- a/health/src/test/java/no/nav/common/health/selftest/SelftestHtmlGeneratorTest.java
+++ b/health/src/test/java/no/nav/common/health/selftest/SelftestHtmlGeneratorTest.java
@@ -16,7 +16,9 @@ public class SelftestHtmlGeneratorTest {
     public void should_generate_selftest_html() throws IOException {
         List<SelfTestCheck> selftestChecks = List.of(
                 new SelfTestCheck("Check 1", false, HealthCheckResult::healthy),
-                new SelfTestCheck("Check 2", true, () -> HealthCheckResult.unhealthy("Something went wrong :("))
+                new SelfTestCheck("Check 2", true, () -> HealthCheckResult.unhealthy("Something went wrong with check 2 :(")),
+                new SelfTestCheck("Check 3", false, () -> HealthCheckResult.unhealthy("Something went wrong with check 3 :(")),
+                new SelfTestCheck("Check 4", true, () -> HealthCheckResult.unhealthy("Something went wrong with check 4 :("))
         );
 
         List<SelftTestCheckResult> checkResults = checkAll(selftestChecks);

--- a/health/src/test/resources/expected-selftest.html
+++ b/health/src/test/resources/expected-selftest.html
@@ -78,13 +78,19 @@
     </tr>
     <tr><td><div class="roundSmallBox ok">OK</div></td><td>Nei</td><td>Xms</td><td>Check 1</td><td></td></tr>
 
-    <tr><td><div class="roundSmallBox error">ERROR</div></td><td>Ja</td><td>Xms</td><td>Check 2</td><td><p class="feilmelding">Something went wrong :(</p></td></tr>
+    <tr><td><div class="roundSmallBoxerror">ERROR</div></td><td>Ja</td><td>Xms</td><td>Check2</td><td><p class="feilmelding">Somethingwentwrongwithcheck2:(</p></td></tr>
+
+    <tr><td><div class="roundSmallBoxwarning">WARNING</div></td><td>Nei</td><td>Xms</td><td>Check3</td><td><p class="feilmelding">Somethingwentwrongwithcheck3:(</p></td></tr>
+
+    <tr><td><div class="roundSmallBoxerror">ERROR</div></td><td>Ja</td><td>Xms</td><td>Check4</td><td><p class="feilmelding">Somethingwentwrongwithcheck4:(</p></td></tr>
 
 </table>
 
 <br>
 
 <h5>Siden generert: +1000000000-01-01 00:00:00</h5>
+
+<h6 id="driftMelding">Check2,Check4</h6>
 
 </body>
 


### PR DESCRIPTION
Det er satt opp noen regler i SiteScope som forventer å finne en tag med id "driftsMelding" som inneholder feilede komponenter.