### PR TITLE
Bump cxf@3.4.0

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -29,7 +29,7 @@
         Vær obs på dette ved oppgradering av cxf
         Ref https://jira.adeo.no/browse/F17HL4-565
         -->
-        <cxf-core.version>3.3.6</cxf-core.version>
+        <cxf-core.version>3.4.0</cxf-core.version>
         <xml-apis.version>1.4.01</xml-apis.version>
 
         <!-- REST -->


### PR DESCRIPTION
Hadde tidligere transitiv avhengighet til ehcache@2.10.6, f.o.m cxf@3.4.0 er ehcache bumpet til 3.8.1 som forhåpentligvis unngår java-9-module problemer.

https://github.com/micrometer-metrics/micrometer/issues/1543
