### PR TITLE
Fikset deserialisering av domenetyper med JsonUtils

### DIFF
--- a/types/pom.xml
+++ b/types/pom.xml
@@ -28,6 +28,11 @@
         </dependency>
 
         <dependency>
+            <groupId>no.nav.common</groupId>
+            <artifactId>json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>

--- a/types/src/main/java/no/nav/common/types/identer/AktorId.java
+++ b/types/src/main/java/no/nav/common/types/identer/AktorId.java
@@ -1,12 +1,15 @@
 package no.nav.common.types.identer;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Representerer aktør IDen til en bruker.
  * Eksempel: 1112223334445
  */
 public class AktorId extends EksternBrukerId {
 
-    private AktorId(String id) {
+    @JsonCreator
+    public AktorId(String id) {
         super(id);
     }
 

--- a/types/src/main/java/no/nav/common/types/identer/AzureObjectId.java
+++ b/types/src/main/java/no/nav/common/types/identer/AzureObjectId.java
@@ -1,12 +1,15 @@
 package no.nav.common.types.identer;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Representerer Azure AD IDen til en saksbehandler (Hentes fra "oid" (Object ID) claimet).
  * Eksempel: aaa123-aaa123-aaa123-aaa123-aaa123
  */
 public class AzureObjectId extends InternBrukerId {
 
-    private AzureObjectId(String id) {
+    @JsonCreator
+    public AzureObjectId(String id) {
         super(id);
     }
 

--- a/types/src/main/java/no/nav/common/types/identer/EnhetId.java
+++ b/types/src/main/java/no/nav/common/types/identer/EnhetId.java
@@ -1,12 +1,15 @@
 package no.nav.common.types.identer;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Representerer IDen til en NAV enhet.
  * Eksempel: 0123
  */
 public class EnhetId extends Id {
 
-    private EnhetId(String id) {
+    @JsonCreator
+    public EnhetId(String id) {
         super(id);
     }
 

--- a/types/src/main/java/no/nav/common/types/identer/Fnr.java
+++ b/types/src/main/java/no/nav/common/types/identer/Fnr.java
@@ -1,12 +1,15 @@
 package no.nav.common.types.identer;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Representerer fødselsnummeret til en bruker.
  * Eksempel: 12345678901
  */
 public class Fnr extends EksternBrukerId {
 
-    private Fnr(String id) {
+    @JsonCreator
+    public Fnr(String id) {
         super(id);
     }
 

--- a/types/src/main/java/no/nav/common/types/identer/Id.java
+++ b/types/src/main/java/no/nav/common/types/identer/Id.java
@@ -1,11 +1,13 @@
 package no.nav.common.types.identer;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public class Id {
 
     private final String id;
 
+    @JsonCreator
     public Id(String id) {
         if (id == null) {
             throw new IllegalArgumentException("Id cannot be null");

--- a/types/src/main/java/no/nav/common/types/identer/NavIdent.java
+++ b/types/src/main/java/no/nav/common/types/identer/NavIdent.java
@@ -1,12 +1,15 @@
 package no.nav.common.types.identer;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Representerer IDen til en NAV ansatt. Som oftest veileder/saksbehandler.
  * Eksempel: Z123456
  */
 public class NavIdent extends InternBrukerId {
 
-    private NavIdent(String id) {
+    @JsonCreator
+    public NavIdent(String id) {
         super(id);
     }
 

--- a/types/src/test/java/no/nav/types/identer/AktorIdTest.java
+++ b/types/src/test/java/no/nav/types/identer/AktorIdTest.java
@@ -2,6 +2,7 @@ package no.nav.types.identer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import no.nav.common.json.JsonUtils;
 import no.nav.common.types.identer.AktorId;
 import org.junit.Test;
 
@@ -19,10 +20,25 @@ public class AktorIdTest {
     }
 
     @Test
+    public void should_serialize_aktorId_to_json_field_with_json_utils() {
+        AktorIdWrapper wrapper = new AktorIdWrapper(AktorId.of("123534252"));
+        assertEquals("{\"aktorId\":\"123534252\"}", JsonUtils.toJson(wrapper));
+    }
+
+    @Test
     public void should_deserialize_json_to_aktorId_field() throws JsonProcessingException {
         String wrapperJson = "{\"aktorId\":\"123534252\"}";
 
         AktorIdWrapper wrapper = mapper.readValue(wrapperJson, AktorIdWrapper.class);
+
+        assertEquals(wrapper.getAktorId().get(), "123534252");
+    }
+
+    @Test
+    public void should_deserialize_json_to_aktorId_field_with_json_utils() {
+        String wrapperJson = "{\"aktorId\":\"123534252\"}";
+
+        AktorIdWrapper wrapper = JsonUtils.fromJson(wrapperJson, AktorIdWrapper.class);
 
         assertEquals(wrapper.getAktorId().get(), "123534252");
     }

--- a/types/src/test/java/no/nav/types/identer/AzureObjectIdTest.java
+++ b/types/src/test/java/no/nav/types/identer/AzureObjectIdTest.java
@@ -2,6 +2,7 @@ package no.nav.types.identer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import no.nav.common.json.JsonUtils;
 import no.nav.common.types.identer.AzureObjectId;
 import org.junit.Test;
 
@@ -19,10 +20,25 @@ public class AzureObjectIdTest {
     }
 
     @Test
+    public void should_serialize_azureObjectId_to_json_field_with_json_utils() {
+        AzureObjectIdWrapper wrapper = new AzureObjectIdWrapper(AzureObjectId.of("123534252"));
+        assertEquals("{\"azureObjectId\":\"123534252\"}", JsonUtils.toJson(wrapper));
+    }
+
+    @Test
     public void should_deserialize_json_to_azureObjectId_field() throws JsonProcessingException {
         String wrapperJson = "{\"azureObjectId\":\"123534252\"}";
 
         AzureObjectIdWrapper wrapper = mapper.readValue(wrapperJson, AzureObjectIdWrapper.class);
+
+        assertEquals(wrapper.getAzureObjectId().get(), "123534252");
+    }
+
+    @Test
+    public void should_deserialize_json_to_azureObjectId_field_with_json_utils() {
+        String wrapperJson = "{\"azureObjectId\":\"123534252\"}";
+
+        AzureObjectIdWrapper wrapper = JsonUtils.fromJson(wrapperJson, AzureObjectIdWrapper.class);
 
         assertEquals(wrapper.getAzureObjectId().get(), "123534252");
     }

--- a/types/src/test/java/no/nav/types/identer/EnhetIdTest.java
+++ b/types/src/test/java/no/nav/types/identer/EnhetIdTest.java
@@ -2,6 +2,7 @@ package no.nav.types.identer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import no.nav.common.json.JsonUtils;
 import no.nav.common.types.identer.EnhetId;
 import org.junit.Test;
 
@@ -19,10 +20,25 @@ public class EnhetIdTest {
     }
 
     @Test
+    public void should_serialize_enhetId_to_json_field_with_json_utils() {
+        EnhetIdWrapper wrapper = new EnhetIdWrapper(EnhetId.of("1234"));
+        assertEquals("{\"enhetId\":\"1234\"}", JsonUtils.toJson(wrapper));
+    }
+
+    @Test
     public void should_deserialize_json_to_enhetId_field() throws JsonProcessingException {
         String wrapperJson = "{\"enhetId\":\"1234\"}";
 
         EnhetIdWrapper wrapper = mapper.readValue(wrapperJson, EnhetIdWrapper.class);
+
+        assertEquals(wrapper.getEnhetId().get(), "1234");
+    }
+
+    @Test
+    public void should_deserialize_json_to_enhetId_field_with_json_utils() {
+        String wrapperJson = "{\"enhetId\":\"1234\"}";
+
+        EnhetIdWrapper wrapper = JsonUtils.fromJson(wrapperJson, EnhetIdWrapper.class);
 
         assertEquals(wrapper.getEnhetId().get(), "1234");
     }

--- a/types/src/test/java/no/nav/types/identer/FnrTest.java
+++ b/types/src/test/java/no/nav/types/identer/FnrTest.java
@@ -2,6 +2,7 @@ package no.nav.types.identer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import no.nav.common.json.JsonUtils;
 import no.nav.common.types.identer.Fnr;
 import org.junit.Test;
 
@@ -19,10 +20,25 @@ public class FnrTest {
     }
 
     @Test
+    public void should_serialize_fnr_to_json_field_with_json_utils() {
+        FnrWrapper wrapper = new FnrWrapper(Fnr.of("123534252"));
+        assertEquals("{\"fnr\":\"123534252\"}", JsonUtils.toJson(wrapper));
+    }
+
+    @Test
     public void should_deserialize_json_to_fnr_field() throws JsonProcessingException {
         String FnrWrapperJson = "{\"fnr\":\"123534252\"}";
 
         FnrWrapper wrapper = mapper.readValue(FnrWrapperJson, FnrWrapper.class);
+
+        assertEquals(wrapper.getFnr().get(), "123534252");
+    }
+
+    @Test
+    public void should_deserialize_json_to_fnr_field_with_json_utils() {
+        String FnrWrapperJson = "{\"fnr\":\"123534252\"}";
+
+        FnrWrapper wrapper = JsonUtils.fromJson(FnrWrapperJson, FnrWrapper.class);
 
         assertEquals(wrapper.getFnr().get(), "123534252");
     }

--- a/types/src/test/java/no/nav/types/identer/NavIdentTest.java
+++ b/types/src/test/java/no/nav/types/identer/NavIdentTest.java
@@ -2,6 +2,7 @@ package no.nav.types.identer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import no.nav.common.json.JsonUtils;
 import no.nav.common.types.identer.NavIdent;
 import org.junit.Test;
 
@@ -19,9 +20,25 @@ public class NavIdentTest {
     }
 
     @Test
+    public void should_serialize_navIdent_to_json_field_with_json_utils() {
+        NavIdentWrapper wrapper = new NavIdentWrapper(NavIdent.of("Z123456"));
+        assertEquals("{\"navIdent\":\"Z123456\"}", JsonUtils.toJson(wrapper));
+    }
+
+    @Test
     public void should_deserialize_json_to_navIdent_field() throws JsonProcessingException {
         String wrapperJson = "{\"navIdent\":\"Z123456\"}";
+
         NavIdentWrapper wrapper = mapper.readValue(wrapperJson, NavIdentWrapper.class);
+
+        assertEquals(wrapper.getNavIdent().get(), "Z123456");
+    }
+
+    @Test
+    public void should_deserialize_json_to_navIdent_field_with_json_utils() {
+        String wrapperJson = "{\"navIdent\":\"Z123456\"}";
+
+        NavIdentWrapper wrapper = JsonUtils.fromJson(wrapperJson, NavIdentWrapper.class);
 
         assertEquals(wrapper.getNavIdent().get(), "Z123456");
     }


### PR DESCRIPTION
Json modulen bruker en ObjectMapper med custom config som ikke får deserialisert domenetypene uten å legge til @JsonCreator