### PR TITLE
Fikset sjekk på tilgang til enhet og la til ny tilgangssjekk

### DIFF
--- a/abac/src/main/java/no/nav/common/abac/Pep.java
+++ b/abac/src/main/java/no/nav/common/abac/Pep.java
@@ -26,6 +26,17 @@ public interface Pep {
     boolean harTilgangTilEnhet(String innloggetBrukerIdToken, EnhetId enhetId);
 
     /**
+     * Sjekk tilgang til enhet med sperre ved å bruke en innlogget brukers ID token.
+     * Brukes for å sjekke tilgang til KVP. Eksterne brukere vil alltid få permit for alle kontorer.
+     *
+     * @param innloggetBrukerIdToken OIDC ID token til innlogget bruker. Kan enten være tokenet til en veileder eller ekstern bruker.
+     * @param enhetId       enheten som det sjekkes tilgang på
+     * @return true hvis tilgang, false hvis ikke tilgang
+     */
+    boolean harTilgangTilEnhetMedSperre(String innloggetBrukerIdToken, EnhetId enhetId);
+
+
+    /**
      * @param veilederIdent     identen til veileder (f.eks Z1234567)
      * @param actionId          hvilken tilgang spørres det etter
      * @param eksternBrukerId   fødselsnummer eller aktørId for personen det sjekkes tilgang på

--- a/abac/src/main/java/no/nav/common/abac/VeilarbPep.java
+++ b/abac/src/main/java/no/nav/common/abac/VeilarbPep.java
@@ -74,22 +74,41 @@ public class VeilarbPep implements Pep {
     }
 
      @Override
-     public boolean harTilgangTilEnhet(String innloggetBrukerIdToken, EnhetId enhetId) {
-         String oidcTokenBody = AbacUtils.extractOidcTokenBody(innloggetBrukerIdToken);
-         Resource resource = lagEnhetResource(enhetId, AbacDomain.VEILARB_DOMAIN);
-         ActionId actionId = ActionId.READ;
+    public boolean harTilgangTilEnhet(String innloggetBrukerIdToken, EnhetId enhetId) {
+        String oidcTokenBody = AbacUtils.extractOidcTokenBody(innloggetBrukerIdToken);
+        Resource resource = lagEnhetResource(enhetId, AbacDomain.VEILARB_DOMAIN);
+        ActionId actionId = ActionId.READ;
 
-         XacmlRequest xacmlRequest = buildRequest(
-                 lagEnvironmentMedOidcTokenBody(srvUsername, oidcTokenBody),
-                 lagAction(actionId),
-                 null,
-                 resource
-         );
+        XacmlRequest xacmlRequest = buildRequest(
+                lagEnvironmentMedOidcTokenBody(srvUsername, oidcTokenBody),
+                lagAction(actionId),
+                null,
+                resource
+        );
 
-         CefAbacResponseMapper mapper = CefAbacResponseMapper.enhetIdMapper(enhetId, actionId, resource);
-         CefAbacEventContext cefEventContext = lagCefEventContext(mapper, subjectProvider.getSubjectFromToken(innloggetBrukerIdToken));
+        CefAbacResponseMapper mapper = CefAbacResponseMapper.enhetIdMapper(enhetId, actionId, resource);
+        CefAbacEventContext cefEventContext = lagCefEventContext(mapper, subjectProvider.getSubjectFromToken(innloggetBrukerIdToken));
 
-         return harTilgang(xacmlRequest, cefEventContext);
+        return harTilgang(xacmlRequest, cefEventContext);
+    }
+
+    @Override
+    public boolean harTilgangTilEnhetMedSperre(String innloggetBrukerIdToken, EnhetId enhetId) {
+        String oidcTokenBody = AbacUtils.extractOidcTokenBody(innloggetBrukerIdToken);
+        Resource resource = lagEnhetMedSperreResource(enhetId, AbacDomain.VEILARB_DOMAIN);
+        ActionId actionId = ActionId.READ;
+
+        XacmlRequest xacmlRequest = buildRequest(
+                lagEnvironmentMedOidcTokenBody(srvUsername, oidcTokenBody),
+                lagAction(actionId),
+                null,
+                resource
+        );
+
+        CefAbacResponseMapper mapper = CefAbacResponseMapper.enhetIdMapper(enhetId, actionId, resource);
+        CefAbacEventContext cefEventContext = lagCefEventContext(mapper, subjectProvider.getSubjectFromToken(innloggetBrukerIdToken));
+
+        return harTilgang(xacmlRequest, cefEventContext);
     }
 
     @Override

--- a/abac/src/main/java/no/nav/common/abac/XacmlRequestBuilder.java
+++ b/abac/src/main/java/no/nav/common/abac/XacmlRequestBuilder.java
@@ -51,6 +51,14 @@ public class XacmlRequestBuilder {
 
     public static Resource lagEnhetResource(EnhetId enhetId, String domain) {
         Resource resource = new Resource();
+        resource.getAttribute().add(new Attribute(NavAttributter.RESOURCE_FELLES_RESOURCE_TYPE, NavAttributter.RESOURCE_FELLES_ENHET));
+        resource.getAttribute().add(new Attribute(NavAttributter.RESOURCE_FELLES_DOMENE, domain));
+        resource.getAttribute().add(new Attribute(NavAttributter.RESOURCE_FELLES_ENHET, enhetId.get()));
+        return resource;
+    }
+
+    public static Resource lagEnhetMedSperreResource(EnhetId enhetId, String domain) {
+        Resource resource = new Resource();
         resource.getAttribute().add(new Attribute(NavAttributter.RESOURCE_FELLES_RESOURCE_TYPE, NavAttributter.RESOURCE_VEILARB_ENHET_EIENDEL));
         resource.getAttribute().add(new Attribute(NavAttributter.RESOURCE_FELLES_DOMENE, domain));
         resource.getAttribute().add(new Attribute(NavAttributter.RESOURCE_VEILARB_KONTOR_LAAS, enhetId.get()));

--- a/abac/src/test/java/no/nav/common/abac/VeilarbPepTest.java
+++ b/abac/src/test/java/no/nav/common/abac/VeilarbPepTest.java
@@ -112,6 +112,27 @@ public class VeilarbPepTest {
     }
 
     @Test
+    public void harTilgangTilEnhetMedSperre__skal_lage_riktig_request() {
+        VeilarbPep veilarbPep = new VeilarbPep(TEST_SRV_USERNAME, genericPermitClient, auditLogger, subjectProvider, auditRequestInfoSupplier);
+        String expectedRequest = getContentFromJsonFile("xacmlrequest-harTilgangTilEnhetMedSperre.json");
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+
+        boolean tilgang = veilarbPep.harTilgangTilEnhetMedSperre(TEST_OIDC_TOKEN, TEST_ENHET_ID);
+
+        assertTrue(tilgang);
+        verify(genericPermitClient, times(1)).sendRawRequest(captor.capture());
+        assertJsonEquals(expectedRequest, captor.getValue());
+    }
+
+    @Test
+    public void harTilgangTilEnhetMedSperre__skal_returnere_false_hvis_ikke_tilgang() {
+        VeilarbPep veilarbPep = new VeilarbPep(TEST_SRV_USERNAME, genericDenyClient, auditLogger, subjectProvider, auditRequestInfoSupplier);
+        boolean tilgang = veilarbPep.harTilgangTilEnhetMedSperre(TEST_OIDC_TOKEN, TEST_ENHET_ID);
+
+        assertFalse(tilgang);
+    }
+
+    @Test
     public void harVeilederTilgangTilPerson__skal_lage_riktig_request() {
         VeilarbPep veilarbPep = new VeilarbPep(TEST_SRV_USERNAME, genericPermitClient, auditLogger, subjectProvider, auditRequestInfoSupplier);
         String expectedRequest = getContentFromJsonFile("xacmlrequest-harVeilederTilgangTilPerson.json");
@@ -384,7 +405,7 @@ public class VeilarbPepTest {
                 " request=" + REQUEST_PATH +
                 " act=" + READ.getId() +
                 " cs2=" + ENHET +
-                " requestContext=" + RESOURCE_VEILARB_ENHET_EIENDEL +
+                " requestContext=" + RESOURCE_FELLES_ENHET +
                 " sourceServiceName=" + VEILARB_DOMAIN +
                 " requestMethod=" + REQUEST_METHOD +
                 " end=" + TIME +
@@ -406,7 +427,7 @@ public class VeilarbPepTest {
                 " dproc=" + CONSUMER_ID +
                 " flexString1=" + Deny +
                 " act=" + READ.getId() +
-                " requestContext=" + RESOURCE_VEILARB_ENHET_EIENDEL +
+                " requestContext=" + RESOURCE_FELLES_ENHET +
                 " sourceServiceName=" + VEILARB_DOMAIN +
                 " cs3Label=deny_cause" +
                 " end=" + TIME +

--- a/abac/src/test/resources/xacmlrequest-harTilgangTilEnhet.json
+++ b/abac/src/test/resources/xacmlrequest-harTilgangTilEnhet.json
@@ -25,14 +25,14 @@
         "Attribute": [
           {
             "AttributeId": "no.nav.abac.attributter.resource.felles.resource_type",
-            "Value": "no.nav.abac.attributter.resource.veilarb.enhet.eiendel"
+            "Value": "no.nav.abac.attributter.resource.felles.enhet"
           },
           {
             "AttributeId": "no.nav.abac.attributter.resource.felles.domene",
             "Value": "veilarb"
           },
           {
-            "AttributeId": "no.nav.abac.attributter.resource.veilarb.kontor_laas",
+            "AttributeId": "no.nav.abac.attributter.resource.felles.enhet",
             "Value": "1234"
           }
         ]

--- a/abac/src/test/resources/xacmlrequest-harTilgangTilEnhetMedSperre.json
+++ b/abac/src/test/resources/xacmlrequest-harTilgangTilEnhetMedSperre.json
@@ -1,22 +1,14 @@
 {
   "Request": {
-    "AccessSubject": {
-      "Attribute": [
-        {
-          "AttributeId": "urn:oasis:names:tc:xacml:1.0:subject:subject-id",
-          "Value": "Z1234"
-        },
-        {
-          "AttributeId": "no.nav.abac.attributter.subject.felles.subjectType",
-          "Value": "InternBruker"
-        }
-      ]
-    },
     "Environment": {
       "Attribute": [
         {
           "AttributeId": "no.nav.abac.attributter.environment.felles.pep_id",
           "Value": "test"
+        },
+        {
+          "AttributeId": "no.nav.abac.attributter.environment.felles.oidc_token_body",
+          "Value": "abc"
         }
       ]
     },
@@ -33,14 +25,14 @@
         "Attribute": [
           {
             "AttributeId": "no.nav.abac.attributter.resource.felles.resource_type",
-            "Value": "no.nav.abac.attributter.resource.felles.enhet"
+            "Value": "no.nav.abac.attributter.resource.veilarb.enhet.eiendel"
           },
           {
             "AttributeId": "no.nav.abac.attributter.resource.felles.domene",
             "Value": "veilarb"
           },
           {
-            "AttributeId": "no.nav.abac.attributter.resource.felles.enhet",
+            "AttributeId": "no.nav.abac.attributter.resource.veilarb.kontor_laas",
             "Value": "1234"
           }
         ]


### PR DESCRIPTION
Den tidligere sjekken på enhet sjekket på enhet med kontorsperre som ikke blir riktig for eksterne brukere som alltid vil få permit.
Fikset sjekken til å bruke riktig ABAC resource og byttet navn på nåværende sjekk til `enhetMedSperre`.