### PR TITLE
Fikset set-env i workflow som har blitt erstattet med $GITHUB_ENV

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
           restore-keys: ${{ runner.os }}-maven-
 
       - name: Create Version
-        run: echo ::set-env name=VERSION::"2.$(TZ="Europe/Oslo" date +%Y.%m.%d_%H.%M)-$(git rev-parse --short=12 HEAD)"
+        run: echo "VERSION=2.$(TZ=\"Europe/Oslo\" date +%Y.%m.%d_%H.%M)-$(git rev-parse --short=12 HEAD)" >> $GITHUB_ENV
 
       - name: Release Maven package
         env:


### PR DESCRIPTION
https://www.zdnet.com/article/google-to-github-times-up-this-unfixed-high-severity-security-bug-affects-developers/