### PR TITLE
Fikset på kafka metrikk navn

### DIFF
--- a/kafka/src/main/java/no/nav/common/kafka/consumer/util/TopicConsumerMetrics.java
+++ b/kafka/src/main/java/no/nav/common/kafka/consumer/util/TopicConsumerMetrics.java
@@ -16,9 +16,9 @@ import java.util.Map;
  */
 public class TopicConsumerMetrics<K, V> implements TopicConsumerListener<K, V> {
 
-    public final static String KAFKA_CONSUMER_STATUS_COUNTER = "kafka.consumer.status";
+    public final static String KAFKA_CONSUMER_STATUS_COUNTER = "kafka_consumer_status";
 
-    public final static String KAFKA_CONSUMER_CONSUMED_OFFSET_GAUGE = "kafka.consumer.consumed-offset";
+    public final static String KAFKA_CONSUMER_CONSUMED_OFFSET_GAUGE = "kafka_consumer_consumed_offset";
 
     private final MeterRegistry meterRegistry;
 

--- a/kafka/src/main/java/no/nav/common/kafka/producer/util/KafkaProducerClientWithMetrics.java
+++ b/kafka/src/main/java/no/nav/common/kafka/producer/util/KafkaProducerClientWithMetrics.java
@@ -17,9 +17,9 @@ import java.util.concurrent.Future;
 
 public class KafkaProducerClientWithMetrics<K, V> implements KafkaProducerClient<K, V> {
 
-    public final static String KAFKA_PRODUCER_STATUS_COUNTER = "kafka.producer.status";
+    public final static String KAFKA_PRODUCER_STATUS_COUNTER = "kafka_producer_status";
 
-    public final static String KAFKA_PRODUCER_CURRENT_OFFSET_GAUGE = "kafka.producer.current-offset";
+    public final static String KAFKA_PRODUCER_CURRENT_OFFSET_GAUGE = "kafka_producer_current_offset";
 
     private final KafkaProducerClient<K, V> client;
 


### PR DESCRIPTION
Tegn som "." og "-" blir byttet ut med "_" når det blir hentet av prometheus så det er ikke farlig å la det være som det er, men det kan være litt forvirrende at navnene er annerledes i prometheus enn det de er i koden.