### PR TITLE
Legg til støtte for konfigurering av KafkaConsumerRecordProcessor

### DIFF
--- a/kafka/src/main/java/no/nav/common/kafka/consumer/feilhandtering/KafkaConsumerRecordProcessorConfig.java
+++ b/kafka/src/main/java/no/nav/common/kafka/consumer/feilhandtering/KafkaConsumerRecordProcessorConfig.java
@@ -1,0 +1,14 @@
+package no.nav.common.kafka.consumer.feilhandtering;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.Duration;
+
+@AllArgsConstructor
+@Data
+public class KafkaConsumerRecordProcessorConfig {
+    Duration errorTimeout;
+    Duration pollTimeout;
+    int recordBatchSize;
+}

--- a/kafka/src/main/java/no/nav/common/kafka/consumer/feilhandtering/util/KafkaConsumerRecordProcessorBuilder.java
+++ b/kafka/src/main/java/no/nav/common/kafka/consumer/feilhandtering/util/KafkaConsumerRecordProcessorBuilder.java
@@ -1,0 +1,84 @@
+package no.nav.common.kafka.consumer.feilhandtering.util;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import no.nav.common.kafka.consumer.feilhandtering.KafkaConsumerRecordProcessor;
+import no.nav.common.kafka.consumer.feilhandtering.KafkaConsumerRecordProcessorConfig;
+import no.nav.common.kafka.consumer.feilhandtering.KafkaConsumerRepository;
+import no.nav.common.kafka.consumer.feilhandtering.StoredRecordConsumer;
+
+import java.time.Duration;
+import java.util.Map;
+
+public class KafkaConsumerRecordProcessorBuilder {
+
+    private final static Duration DEFAULT_ERROR_TIMEOUT = Duration.ofMinutes(1);
+    private final static Duration DEFAULT_POLL_TIMEOUT = Duration.ofSeconds(30);
+    private final static int DEFAULT_RECORDS_BATCH_SIZE = 100;
+
+    private KafkaConsumerRecordProcessorBuilder() { }
+
+    private LockProvider lockProvider;
+
+    private KafkaConsumerRepository kafkaConsumerRepository;
+
+    private Map<String, StoredRecordConsumer> recordConsumers;
+
+    private final KafkaConsumerRecordProcessorConfig config = new KafkaConsumerRecordProcessorConfig(
+            DEFAULT_ERROR_TIMEOUT,
+            DEFAULT_POLL_TIMEOUT,
+            DEFAULT_RECORDS_BATCH_SIZE);;
+
+    public static KafkaConsumerRecordProcessorBuilder builder() {
+        return new KafkaConsumerRecordProcessorBuilder();
+    }
+
+    public KafkaConsumerRecordProcessorBuilder withLockProvider(LockProvider lockProvider) {
+        this.lockProvider = lockProvider;
+        return this;
+    }
+
+    public KafkaConsumerRecordProcessorBuilder withKafkaConsumerRepository(KafkaConsumerRepository kafkaConsumerRepository) {
+        this.kafkaConsumerRepository = kafkaConsumerRepository;
+        return this;
+    }
+
+    public KafkaConsumerRecordProcessorBuilder withRecordConsumers(Map<String, StoredRecordConsumer> recordConsumers) {
+        this.recordConsumers = recordConsumers;
+        return this;
+    }
+
+    public KafkaConsumerRecordProcessorBuilder withErrorTimeout(Duration errorTimeout) {
+        this.config.setErrorTimeout(errorTimeout);
+        return this;
+    }
+
+    public KafkaConsumerRecordProcessorBuilder withPollTimeout(Duration pollTimeout) {
+        this.config.setPollTimeout(pollTimeout);
+        return this;
+    }
+
+    public KafkaConsumerRecordProcessorBuilder withRecordBatchSize(int recordBatchSize) {
+        this.config.setRecordBatchSize(recordBatchSize);
+        return this;
+    }
+
+    public KafkaConsumerRecordProcessor build() {
+        if (lockProvider == null) {
+            throw new IllegalStateException("Cannot build kafka consumer record processor without lockProvider");
+        }
+
+        if (kafkaConsumerRepository == null) {
+            throw new IllegalStateException("Cannot build kafka consumer record processor without kafkaConsumerRepository");
+        }
+
+        if (recordConsumers == null) {
+            throw new IllegalStateException("Cannot build kafka consumer record processor without recordConsumers");
+        }
+
+        return new KafkaConsumerRecordProcessor(
+                lockProvider,
+                kafkaConsumerRepository,
+                recordConsumers,
+                config);
+    }
+}

--- a/kafka/src/test/java/no/nav/common/kafka/consumer/feilhandtering/KafkaConsumerRecordProcessorIntegrationTest.java
+++ b/kafka/src/test/java/no/nav/common/kafka/consumer/feilhandtering/KafkaConsumerRecordProcessorIntegrationTest.java
@@ -3,6 +3,7 @@ package no.nav.common.kafka.consumer.feilhandtering;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.core.SimpleLock;
 import no.nav.common.kafka.consumer.ConsumeStatus;
+import no.nav.common.kafka.consumer.feilhandtering.util.KafkaConsumerRecordProcessorBuilder;
 import no.nav.common.kafka.utils.LocalH2Database;
 import org.junit.After;
 import org.junit.Before;
@@ -56,11 +57,13 @@ public class KafkaConsumerRecordProcessorIntegrationTest {
                 }
         );
 
-        KafkaConsumerRecordProcessor consumerRecordProcessor = new KafkaConsumerRecordProcessor(
-                lockProvider,
-                consumerRepository,
-                storedRecordConsumers
-        );
+        KafkaConsumerRecordProcessor consumerRecordProcessor =
+                KafkaConsumerRecordProcessorBuilder
+                        .builder()
+                        .withLockProvider(lockProvider)
+                        .withKafkaConsumerRepository(consumerRepository)
+                        .withRecordConsumers(storedRecordConsumers)
+                        .build();
 
         consumerRepository.storeRecord(storedRecord(TEST_TOPIC_A, 1, 1, "key1", "value"));
         consumerRepository.storeRecord(storedRecord(TEST_TOPIC_A, 2, 1, "key2", "value"));
@@ -105,11 +108,13 @@ public class KafkaConsumerRecordProcessorIntegrationTest {
                 }
         );
 
-        KafkaConsumerRecordProcessor consumerRecordProcessor = new KafkaConsumerRecordProcessor(
-                lockProvider,
-                consumerRepository,
-                storedRecordConsumers
-        );
+        KafkaConsumerRecordProcessor consumerRecordProcessor =
+                KafkaConsumerRecordProcessorBuilder
+                        .builder()
+                        .withLockProvider(lockProvider)
+                        .withKafkaConsumerRepository(consumerRepository)
+                        .withRecordConsumers(storedRecordConsumers)
+                        .build();
 
         consumerRepository.storeRecord(storedRecord(TEST_TOPIC_A, 1, 1, "key1", "value"));
         consumerRepository.storeRecord(storedRecord(TEST_TOPIC_A, 2, 1, "key2", "value"));


### PR DESCRIPTION
Mulighet for konfigurering av timeouts og batch-størrelse via config-objekt. Builder-klasse for KafkaConsumerRecordProcessor. Høyere default verdier for timeouts.