### PR TITLE
Custom exceptions for error og manglende data i Graphql

### DIFF
--- a/client/src/main/java/no/nav/common/client/utils/graphql/GraphqlErrorException.java
+++ b/client/src/main/java/no/nav/common/client/utils/graphql/GraphqlErrorException.java
@@ -1,0 +1,22 @@
+package no.nav.common.client.utils.graphql;
+
+import java.util.List;
+
+public class GraphqlErrorException extends RuntimeException {
+
+    private final List<GraphqlError> errors;
+
+    public GraphqlErrorException(String message, List<GraphqlError> errors) {
+        super(message);
+        this.errors = errors;
+    }
+
+    public GraphqlErrorException(List<GraphqlError> errors) {
+        this("Graphql response contains errors", errors);
+    }
+
+    public List<GraphqlError> getErrors() {
+        return errors;
+    }
+
+}

--- a/client/src/main/java/no/nav/common/client/utils/graphql/GraphqlNoDataException.java
+++ b/client/src/main/java/no/nav/common/client/utils/graphql/GraphqlNoDataException.java
@@ -1,0 +1,13 @@
+package no.nav.common.client.utils.graphql;
+
+public class GraphqlNoDataException extends RuntimeException {
+
+    public GraphqlNoDataException() {
+        super("Graphql response mangler data");
+    }
+
+    public GraphqlNoDataException(String message) {
+        super(message);
+    }
+
+}

--- a/client/src/main/java/no/nav/common/client/utils/graphql/GraphqlUtils.java
+++ b/client/src/main/java/no/nav/common/client/utils/graphql/GraphqlUtils.java
@@ -13,21 +13,21 @@ public class GraphqlUtils {
 
     public static void logWarningIfError(GraphqlResponse<?> response) {
         if (response.getErrors() != null) {
-            log.warn("Graphql request feilet med feilmelding: " + JsonUtils.toJson(response.getErrors()));
+            log.warn("Graphql response feilet med feilmelding: " + JsonUtils.toJson(response.getErrors()));
         }
     }
 
     public static void throwIfError(GraphqlResponse<?> response) {
         if (response.getErrors() != null) {
-            log.error("Graphql request feilet med feilmelding: " + JsonUtils.toJson(response.getErrors()));
-            throw new RuntimeException("Graphql request feilet");
+            log.error("Graphql response feilet med feilmelding: " + JsonUtils.toJson(response.getErrors()));
+            throw new GraphqlErrorException(response.errors);
         }
     }
 
     public static void throwIfMissingData(GraphqlResponse<?> response) {
         if (response.getData() == null) {
-            log.error("Graphql request mangler data");
-            throw new RuntimeException("Graphql request mangler data");
+            log.error("Graphql response mangler data");
+            throw new GraphqlNoDataException();
         }
     }
 }


### PR DESCRIPTION
Istedenfor å kaste vanlige exceptions så er det bedre å kaste custom exceptions som gir brukeren av klienten mulighet til å gjøre feilhåndtering med informasjon fra responsen.