### PR TITLE
La til consumer-id compliance filter

### DIFF
--- a/rest/src/main/java/no/nav/common/rest/filter/ConsumerIdComplianceFilter.java
+++ b/rest/src/main/java/no/nav/common/rest/filter/ConsumerIdComplianceFilter.java
@@ -1,0 +1,57 @@
+package no.nav.common.rest.filter;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+
+import static no.nav.common.log.LogFilter.CONSUMER_ID_HEADER_NAME;
+
+@Slf4j
+public class ConsumerIdComplianceFilter implements Filter {
+
+    private final boolean enforceCompliance;
+
+    public ConsumerIdComplianceFilter(boolean enforceCompliance) {
+        this.enforceCompliance = enforceCompliance;
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+
+        boolean isMissingConsumerId = getHeader(request, CONSUMER_ID_HEADER_NAME).isEmpty();
+
+        if (isMissingConsumerId) {
+            log.warn("Request is missing consumer id, enforcingCompliance={}", enforceCompliance);
+
+            if (enforceCompliance) {
+                HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+                response.setStatus(400);
+                response.getWriter().write(
+                        "Bad request: Consumer id is missing from header: " + CONSUMER_ID_HEADER_NAME +
+                                ". Make sure to set the header with the name of the requesting application."
+                );
+                response.getWriter().flush();
+                return;
+            }
+        }
+
+        chain.doFilter(servletRequest, servletResponse);
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) {}
+
+    @Override
+    public void destroy() {}
+
+    private Optional<String> getHeader(HttpServletRequest request, String headerName) {
+        return Optional.ofNullable(request.getHeader(headerName));
+    }
+
+}

--- a/rest/src/test/java/no/nav/common/rest/filter/ConsumerIdComplianceFilterTest.java
+++ b/rest/src/test/java/no/nav/common/rest/filter/ConsumerIdComplianceFilterTest.java
@@ -1,0 +1,65 @@
+package no.nav.common.rest.filter;
+
+import org.junit.Test;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static org.mockito.Mockito.*;
+
+public class ConsumerIdComplianceFilterTest {
+
+    @Test
+    public void should_return_400_if_missing_header_and_enforcing_compliance() throws IOException, ServletException {
+        var filter = new ConsumerIdComplianceFilter(true);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        when(request.getHeader("Nav-Consumer-Id")).thenReturn(null);
+        when(response.getWriter()).thenReturn(mock(PrintWriter.class));
+
+        filter.doFilter(request, response, chain);
+
+        verify(response, times(1)).setStatus(400);
+        verifyZeroInteractions(chain);
+    }
+
+    @Test
+    public void should_forward_if_missing_header_and_not_enforcing_compliance() throws IOException, ServletException {
+        var filter = new ConsumerIdComplianceFilter(false);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        when(request.getHeader("Nav-Consumer-Id")).thenReturn(null);
+
+        filter.doFilter(request, response, chain);
+
+        verifyZeroInteractions(response);
+        verify(chain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    public void should_forward_if_request_has_consumer_id_and_enforcing_compliance() throws IOException, ServletException {
+        var filter = new ConsumerIdComplianceFilter(true);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        when(request.getHeader("Nav-Consumer-Id")).thenReturn("some-application");
+
+        filter.doFilter(request, response, chain);
+
+        verifyZeroInteractions(response);
+        verify(chain, times(1)).doFilter(request, response);
+    }
+
+}


### PR DESCRIPTION
Alle requests som blir sendt til en backend burde inneholde headeren Nav-Consumer-Id slik at vi får kontroll over hvem som sender requests. Tanken er å kun skru på enforcement i dev, slik at det ikke påvirker ting som kjører i prod.