### PR TITLE
Legger til støtte for å skru av Sensu-metrics

### DIFF
--- a/api-app/README.md
+++ b/api-app/README.md
@@ -62,3 +62,9 @@ Cache-Control-headeren vil da se slik ut:
 `Cache-Control: no-cache`
 
 Man kan også fjerne Pragma-headeren ved å definere `DISABLE_PRAGMA_HEADER=true`
+
+### Annen konfigurasjon
+
+Metrics sendes ut av boksen til `sensu.nais:3030`, men dette kan deaktiveres ved å definere følgende miljøvariabel:
+
+`DISABLE_SENSU_METRICS=true`

--- a/api-app/src/main/java/no/nav/apiapp/ApiApp.java
+++ b/api-app/src/main/java/no/nav/apiapp/ApiApp.java
@@ -42,6 +42,8 @@ public class ApiApp {
     public static final String NAV_TRUSTSTORE_PATH = "NAV_TRUSTSTORE_PATH";
     public static final String NAV_TRUSTSTORE_PASSWORD = "NAV_TRUSTSTORE_PASSWORD";
 
+    public static final String DISABLE_SENSU_METRICS = "DISABLE_SENSU_METRICS";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ApiApp.class);
 
     static final int DEFAULT_HTTP_PORT = 8080;

--- a/api-app/src/main/java/no/nav/apiapp/ApiAppServletContextListener.java
+++ b/api-app/src/main/java/no/nav/apiapp/ApiAppServletContextListener.java
@@ -154,7 +154,11 @@ public class ApiAppServletContextListener implements ServletContextListener, Htt
             leggTilServlet(servletContextEvent, new SoapServlet(), WEBSERVICE_PATH);
         }
 
-        MetricsClient.enableMetrics(MetricsConfig.resolveNaisConfig());
+        if (sensuMetricsBrukes()) {
+            MetricsClient.enableMetrics(MetricsConfig.resolveNaisConfig());
+        } else {
+            LOGGER.info("Sensu metrics deaktivert");
+        }
 
         webApplicationContext.getAutowireCapableBeanFactory().autowireBean(apiApplication);
 
@@ -167,6 +171,11 @@ public class ApiAppServletContextListener implements ServletContextListener, Htt
         pingables.addAll(webApplicationContext.getBeansOfType(Pingable.class).values());
         pingables.addAll(konfigurator.getPingables());
         return pingables;
+    }
+
+    private boolean sensuMetricsBrukes() {
+        boolean sensuDisabled = getOptionalProperty(ApiApp.DISABLE_SENSU_METRICS).map(Boolean::parseBoolean).orElse(false);
+        return !sensuDisabled;
     }
 
     private boolean stsBrukes() {


### PR DESCRIPTION
Sensu tar imot InfluxDB-metrics fra ApiApp.

Sensu eksisterer ikke i GCP, og en annen metrics-tjeneste må i stedet benyttes.
InfluxDB-metrics trengs ikke i alle apper som bruker ApiApp, så et alternativ her er å deaktivere den.

Denne endringen legger til environment-variabelet `DISABLE_SENSU_METRICS`, som kan settes til `true` for å skru av sensu/influx-metrics.