### PR TITLE
Fikset set-env i workflow som har blitt erstattet med $GITHUB_ENV

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
           restore-keys: ${{ runner.os }}-maven-
 
       - name: Create Version
-        run: echo ::set-env name=VERSION::"1.$(TZ="Europe/Oslo" date +%Y.%m.%d_%H.%M)-$(git rev-parse --short=12 HEAD)"
+        run: echo "VERSION=1.$(TZ=\"Europe/Oslo\" date +%Y.%m.%d_%H.%M)-$(git rev-parse --short=12 HEAD)" >> $GITHUB_ENV
 
       - name: Release Maven package
         env:


### PR DESCRIPTION
Cherry-picket fra `43429c367b79745805763b7b0d2d5ea3a75aaabf`