### PR TITLE
Endre impl av Kafka-repos til å bruke Spring JdbcTemplate

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -203,6 +203,12 @@
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
+                <artifactId>spring-jdbc</artifactId>
+                <version>${spring.version}</version>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
                 <artifactId>spring-test</artifactId>
                 <version>${spring.version}</version>
                 <scope>test</scope>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -68,6 +68,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jdbc</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>no.nav.common</groupId>
             <artifactId>json</artifactId>
         </dependency>

--- a/kafka/src/main/java/no/nav/common/kafka/spring/DatabaseUtils.java
+++ b/kafka/src/main/java/no/nav/common/kafka/spring/DatabaseUtils.java
@@ -1,4 +1,4 @@
-package no.nav.common.kafka.util;
+package no.nav.common.kafka.spring;
 
 import lombok.SneakyThrows;
 import no.nav.common.kafka.consumer.feilhandtering.StoredConsumerRecord;

--- a/kafka/src/main/java/no/nav/common/kafka/spring/OracleJdbcTemplateProducerRepository.java
+++ b/kafka/src/main/java/no/nav/common/kafka/spring/OracleJdbcTemplateProducerRepository.java
@@ -1,28 +1,29 @@
-package no.nav.common.kafka.producer.feilhandtering;
+package no.nav.common.kafka.spring;
 
 import lombok.SneakyThrows;
-import no.nav.common.kafka.util.DatabaseUtils;
+import no.nav.common.kafka.producer.feilhandtering.KafkaProducerRepository;
+import no.nav.common.kafka.producer.feilhandtering.StoredProducerRecord;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.util.List;
 
 import static java.lang.String.format;
 import static no.nav.common.kafka.util.DatabaseConstants.*;
-import static no.nav.common.kafka.util.DatabaseUtils.inClause;
-import static no.nav.common.kafka.util.DatabaseUtils.incrementAndGetOracleSequence;
+import static no.nav.common.kafka.spring.DatabaseUtils.inClause;
+import static no.nav.common.kafka.spring.DatabaseUtils.incrementAndGetOracleSequence;
 
-public class OracleProducerRepository implements KafkaProducerRepository {
+public class OracleJdbcTemplateProducerRepository implements KafkaProducerRepository {
 
     private final JdbcTemplate jdbcTemplate;
 
     private final String producerRecordTable;
 
-    public OracleProducerRepository(JdbcTemplate jdbcTemplate, String producerRecordTableName) {
+    public OracleJdbcTemplateProducerRepository(JdbcTemplate jdbcTemplate, String producerRecordTableName) {
         this.jdbcTemplate = jdbcTemplate;
         this.producerRecordTable = producerRecordTableName;
     }
 
-    public OracleProducerRepository(JdbcTemplate jdbcTemplate) {
+    public OracleJdbcTemplateProducerRepository(JdbcTemplate jdbcTemplate) {
         this(jdbcTemplate, PRODUCER_RECORD_TABLE);
     }
 

--- a/kafka/src/main/java/no/nav/common/kafka/spring/PostgresJdbcTemplateProducerRepository.java
+++ b/kafka/src/main/java/no/nav/common/kafka/spring/PostgresJdbcTemplateProducerRepository.java
@@ -1,28 +1,29 @@
-package no.nav.common.kafka.producer.feilhandtering;
+package no.nav.common.kafka.spring;
 
 import lombok.SneakyThrows;
-import no.nav.common.kafka.util.DatabaseUtils;
+import no.nav.common.kafka.producer.feilhandtering.KafkaProducerRepository;
+import no.nav.common.kafka.producer.feilhandtering.StoredProducerRecord;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.util.List;
 
 import static java.lang.String.format;
 import static no.nav.common.kafka.util.DatabaseConstants.*;
-import static no.nav.common.kafka.util.DatabaseUtils.incrementAndGetPostgresSequence;
-import static no.nav.common.kafka.util.DatabaseUtils.toPostgresArray;
+import static no.nav.common.kafka.spring.DatabaseUtils.incrementAndGetPostgresSequence;
+import static no.nav.common.kafka.spring.DatabaseUtils.toPostgresArray;
 
-public class PostgresProducerRepository implements KafkaProducerRepository {
+public class PostgresJdbcTemplateProducerRepository implements KafkaProducerRepository {
 
     private final JdbcTemplate jdbcTemplate;
 
     private final String producerRecordTable;
 
-    public PostgresProducerRepository(JdbcTemplate jdbcTemplate, String producerRecordTableName) {
+    public PostgresJdbcTemplateProducerRepository(JdbcTemplate jdbcTemplate, String producerRecordTableName) {
         this.jdbcTemplate = jdbcTemplate;
         this.producerRecordTable = producerRecordTableName;
     }
 
-    public PostgresProducerRepository(JdbcTemplate jdbcTemplate) {
+    public PostgresJdbcTemplateProducerRepository(JdbcTemplate jdbcTemplate) {
         this(jdbcTemplate, PRODUCER_RECORD_TABLE);
     }
 

--- a/kafka/src/main/java/no/nav/common/kafka/util/DatabaseUtils.java
+++ b/kafka/src/main/java/no/nav/common/kafka/util/DatabaseUtils.java
@@ -4,13 +4,13 @@ import lombok.SneakyThrows;
 import no.nav.common.kafka.consumer.feilhandtering.StoredConsumerRecord;
 import no.nav.common.kafka.producer.feilhandtering.StoredProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.springframework.jdbc.core.JdbcTemplate;
 
-import java.sql.Connection;
 import java.sql.ResultSet;
-import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static no.nav.common.kafka.util.DatabaseConstants.*;
@@ -75,32 +75,20 @@ public class DatabaseUtils {
     }
 
     @SneakyThrows
-    public static long incrementAndGetPostgresSequence(Connection connection, String sequenceName) {
+    public static long incrementAndGetPostgresSequence(JdbcTemplate jdbcTemplate, String sequenceName) {
         String sql = format("SELECT nextval('%s')", sequenceName);
-
-        try(Statement statement = connection.createStatement()) {
-            return fetchSequence(statement.executeQuery(sql));
-        }
+        return fetchSequence(jdbcTemplate, sql);
     }
 
     @SneakyThrows
-    public static long incrementAndGetOracleSequence(Connection connection, String sequenceName) {
+    public static long incrementAndGetOracleSequence(JdbcTemplate jdbcTemplate, String sequenceName) {
         String sql = format("SELECT %s.NEXTVAL FROM dual", sequenceName);
-
-        try(Statement statement = connection.createStatement()) {
-            return fetchSequence(statement.executeQuery(sql));
-        }
+        return fetchSequence(jdbcTemplate, sql);
     }
 
     @SneakyThrows
-    public static long fetchSequence(ResultSet resultSet) {
-        try (resultSet) {
-            if (!resultSet.next()) {
-                throw new IllegalStateException("Result set does not contain sequence");
-            }
-
-            return resultSet.getLong(1);
-        }
+    private static long fetchSequence(JdbcTemplate jdbcTemplate, String sql) {
+        return jdbcTemplate.queryForObject(sql, (rs, rn) -> rs.getLong(1));
     }
 
     public static String inClause(int number) {
@@ -114,5 +102,9 @@ public class DatabaseUtils {
         }
         sb.append(")");
         return sb.toString();
+    }
+
+    public static String toPostgresArray(List<?> values) {
+        return "{" + values.stream().map(Object::toString).collect(Collectors.joining(",")) + "}";
     }
 }

--- a/kafka/src/test/java/no/nav/common/kafka/consumer/feilhandtering/KafkaConsumerRecordProcessorIntegrationTest.java
+++ b/kafka/src/test/java/no/nav/common/kafka/consumer/feilhandtering/KafkaConsumerRecordProcessorIntegrationTest.java
@@ -6,6 +6,7 @@ import net.javacrumbs.shedlock.core.SimpleLock;
 import no.nav.common.kafka.consumer.ConsumeStatus;
 import no.nav.common.kafka.consumer.feilhandtering.util.KafkaConsumerRecordProcessorBuilder;
 import no.nav.common.kafka.consumer.util.TopicConsumerConfig;
+import no.nav.common.kafka.spring.PostgresJdbcTemplateConsumerRepository;
 import no.nav.common.kafka.utils.DbUtils;
 import org.junit.*;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -48,7 +49,7 @@ public class KafkaConsumerRecordProcessorIntegrationTest {
 
     @Before
     public void setup() {
-        consumerRepository = new PostgresConsumerRepository(new JdbcTemplate(dataSource));
+        consumerRepository = new PostgresJdbcTemplateConsumerRepository(new JdbcTemplate(dataSource));
     }
 
     @After

--- a/kafka/src/test/java/no/nav/common/kafka/consumer/feilhandtering/KafkaConsumerRepositoryTest.java
+++ b/kafka/src/test/java/no/nav/common/kafka/consumer/feilhandtering/KafkaConsumerRepositoryTest.java
@@ -13,6 +13,7 @@ import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import javax.sql.DataSource;
@@ -35,12 +36,12 @@ public class KafkaConsumerRepositoryTest {
         postgreSQLContainer.start();
         DataSource postgres = createPostgresDataSource(postgreSQLContainer);
         DbUtils.runScript(postgres, "kafka-consumer-record-postgres.sql");
-        PostgresConsumerRepository postgresConsumerRepository = new PostgresConsumerRepository(postgres);
+        PostgresConsumerRepository postgresConsumerRepository = new PostgresConsumerRepository(new JdbcTemplate(postgres));
 
         DataSource oracle = LocalOracleH2Database.createDatabase();
         DbUtils.runScript(oracle, "kafka-consumer-record-oracle.sql");
         DbUtils.runScript(oracle, "oracle-mock.sql");
-        OracleConsumerRepository oracleConsumerRepository = new OracleConsumerRepository(oracle);
+        OracleConsumerRepository oracleConsumerRepository = new OracleConsumerRepository(new JdbcTemplate(oracle));
 
         return Arrays.asList(
                 new Object[]{"POSTGRES", postgres, postgresConsumerRepository},

--- a/kafka/src/test/java/no/nav/common/kafka/consumer/feilhandtering/KafkaConsumerRepositoryTest.java
+++ b/kafka/src/test/java/no/nav/common/kafka/consumer/feilhandtering/KafkaConsumerRepositoryTest.java
@@ -1,6 +1,8 @@
 package no.nav.common.kafka.consumer.feilhandtering;
 
 import no.nav.common.kafka.consumer.util.ConsumerUtils;
+import no.nav.common.kafka.spring.OracleJdbcTemplateConsumerRepository;
+import no.nav.common.kafka.spring.PostgresJdbcTemplateConsumerRepository;
 import no.nav.common.kafka.utils.DbUtils;
 import no.nav.common.kafka.utils.LocalOracleH2Database;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -36,12 +38,12 @@ public class KafkaConsumerRepositoryTest {
         postgreSQLContainer.start();
         DataSource postgres = createPostgresDataSource(postgreSQLContainer);
         DbUtils.runScript(postgres, "kafka-consumer-record-postgres.sql");
-        PostgresConsumerRepository postgresConsumerRepository = new PostgresConsumerRepository(new JdbcTemplate(postgres));
+        PostgresJdbcTemplateConsumerRepository postgresConsumerRepository = new PostgresJdbcTemplateConsumerRepository(new JdbcTemplate(postgres));
 
         DataSource oracle = LocalOracleH2Database.createDatabase();
         DbUtils.runScript(oracle, "kafka-consumer-record-oracle.sql");
         DbUtils.runScript(oracle, "oracle-mock.sql");
-        OracleConsumerRepository oracleConsumerRepository = new OracleConsumerRepository(new JdbcTemplate(oracle));
+        OracleJdbcTemplateConsumerRepository oracleConsumerRepository = new OracleJdbcTemplateConsumerRepository(new JdbcTemplate(oracle));
 
         return Arrays.asList(
                 new Object[]{"POSTGRES", postgres, postgresConsumerRepository},

--- a/kafka/src/test/java/no/nav/common/kafka/producer/feilhandtering/KafkaProducerRecordProcessorIntegrationTest.java
+++ b/kafka/src/test/java/no/nav/common/kafka/producer/feilhandtering/KafkaProducerRecordProcessorIntegrationTest.java
@@ -6,6 +6,7 @@ import no.nav.common.kafka.consumer.KafkaConsumerClientConfig;
 import no.nav.common.kafka.consumer.KafkaConsumerClientImpl;
 import no.nav.common.kafka.producer.KafkaProducerClient;
 import no.nav.common.kafka.producer.KafkaProducerClientImpl;
+import no.nav.common.kafka.spring.OracleJdbcTemplateProducerRepository;
 import no.nav.common.kafka.utils.DbUtils;
 import no.nav.common.kafka.utils.LocalOracleH2Database;
 import org.apache.kafka.clients.CommonClientConfigs;
@@ -58,7 +59,7 @@ public class KafkaProducerRecordProcessorIntegrationTest {
 
         dataSource = LocalOracleH2Database.createDatabase();
         DbUtils.runScript(dataSource, "kafka-producer-record-oracle.sql");
-        producerRepository = new OracleProducerRepository(new JdbcTemplate(dataSource));
+        producerRepository = new OracleJdbcTemplateProducerRepository(new JdbcTemplate(dataSource));
 
         AdminClient admin = KafkaAdminClient.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, brokerUrl));
         admin.deleteTopics(List.of(TEST_TOPIC_A, TEST_TOPIC_B));

--- a/kafka/src/test/java/no/nav/common/kafka/producer/feilhandtering/KafkaProducerRecordProcessorIntegrationTest.java
+++ b/kafka/src/test/java/no/nav/common/kafka/producer/feilhandtering/KafkaProducerRecordProcessorIntegrationTest.java
@@ -16,6 +16,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -46,8 +47,8 @@ public class KafkaProducerRecordProcessorIntegrationTest {
         String brokerUrl = kafka.getBootstrapServers();
 
         dataSource = LocalOracleH2Database.createDatabase();
-        DbUtils.runScript(dataSource, "kafka-producer-record-postgres.sql");
-        producerRepository = new PostgresProducerRepository(dataSource);
+        DbUtils.runScript(dataSource, "kafka-producer-record-oracle.sql");
+        producerRepository = new OracleProducerRepository(new JdbcTemplate(dataSource));
 
         AdminClient admin = KafkaAdminClient.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, brokerUrl));
         admin.deleteTopics(List.of(TEST_TOPIC_A, TEST_TOPIC_B));

--- a/kafka/src/test/java/no/nav/common/kafka/producer/feilhandtering/KafkaProducerRecordProcessorIntegrationTest.java
+++ b/kafka/src/test/java/no/nav/common/kafka/producer/feilhandtering/KafkaProducerRecordProcessorIntegrationTest.java
@@ -12,11 +12,10 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.*;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -42,8 +41,19 @@ public class KafkaProducerRecordProcessorIntegrationTest {
 
     private KafkaProducerRepository producerRepository;
 
+    private KafkaProducerRecordProcessor recordProcessor;
+
+    private KafkaConsumerClientImpl<String, String> consumerClient;
+
+    private AtomicInteger counterTopicA = new AtomicInteger();
+
+    private AtomicInteger counterTopicB = new AtomicInteger();
+
     @Before
     public void setup() {
+        counterTopicA.set(0);
+        counterTopicB.set(0);
+
         String brokerUrl = kafka.getBootstrapServers();
 
         dataSource = LocalOracleH2Database.createDatabase();
@@ -57,6 +67,31 @@ public class KafkaProducerRecordProcessorIntegrationTest {
                 new NewTopic(TEST_TOPIC_B, 1, (short) 1)
         ));
         admin.close(); // Apply changes
+
+        KafkaProducerClient<byte[], byte[]> producer = new KafkaProducerClientImpl<>(kafkaTestByteProducerProperties(kafka.getBootstrapServers()));
+        LeaderElectionClient leaderElectionClient = () -> true;
+
+        recordProcessor = new KafkaProducerRecordProcessor(
+                producerRepository,
+                producer,
+                leaderElectionClient
+        );
+
+        KafkaConsumerClientConfig<String, String> config = new KafkaConsumerClientConfig<>(
+                kafkaTestConsumerProperties(kafka.getBootstrapServers()),
+                Map.of(
+                        TEST_TOPIC_A, (r) -> {
+                            counterTopicA.incrementAndGet();
+                            return ConsumeStatus.OK;
+                        },
+                        TEST_TOPIC_B, (r) -> {
+                            counterTopicB.incrementAndGet();
+                            return ConsumeStatus.OK;
+                        }
+                )
+        );
+
+        consumerClient = new KafkaConsumerClientImpl<>(config);
     }
 
     @After
@@ -73,37 +108,9 @@ public class KafkaProducerRecordProcessorIntegrationTest {
         producerRepository.storeRecord(storedRecord(TEST_TOPIC_B, "value1", "key1"));
         producerRepository.storeRecord(storedRecord(TEST_TOPIC_B, "value2", "key2"));
 
-        KafkaProducerClient<byte[], byte[]> producer = new KafkaProducerClientImpl<>(kafkaTestByteProducerProperties(kafka.getBootstrapServers()));
-        LeaderElectionClient leaderElectionClient = () -> true;
-
-        KafkaProducerRecordProcessor recordProcessor = new KafkaProducerRecordProcessor(
-                producerRepository,
-                producer,
-                leaderElectionClient
-        );
-
         recordProcessor.start();
         Thread.sleep(1000);
         recordProcessor.close();
-
-        AtomicInteger counterTopicA = new AtomicInteger();
-        AtomicInteger counterTopicB = new AtomicInteger();
-
-        KafkaConsumerClientConfig<String, String> config = new KafkaConsumerClientConfig<>(
-                kafkaTestConsumerProperties(kafka.getBootstrapServers()),
-                Map.of(
-                        TEST_TOPIC_A, (r) -> {
-                            counterTopicA.incrementAndGet();
-                            return ConsumeStatus.OK;
-                        },
-                        TEST_TOPIC_B, (r) -> {
-                            counterTopicB.incrementAndGet();
-                            return ConsumeStatus.OK;
-                        }
-                )
-        );
-
-        KafkaConsumerClientImpl<String, String> consumerClient = new KafkaConsumerClientImpl<>(config);
 
         consumerClient.start();
         Thread.sleep(1000);
@@ -113,6 +120,30 @@ public class KafkaProducerRecordProcessorIntegrationTest {
         assertEquals(2, counterTopicB.get());
         assertTrue(producerRepository.getRecords(10).isEmpty());
     }
+
+    @Test
+    public void should_not_send_records_to_kafka_stored_in_a_transaction_that_gets_rolled_back() throws InterruptedException {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(new DataSourceTransactionManager(dataSource));
+
+        consumerClient.start();
+        recordProcessor.start();
+
+        transactionTemplate.execute(status -> {
+            producerRepository.storeRecord(storedRecord(TEST_TOPIC_A, "value1", "key1"));
+            try {
+                Thread.sleep(4000);
+            } catch (InterruptedException ignored) {
+            }
+            status.setRollbackOnly();
+            return null;
+        });
+        Thread.sleep(4000);
+
+        recordProcessor.close();
+        consumerClient.stop();
+        assertEquals(0, counterTopicA.get());
+    }
+
 
     private StoredProducerRecord storedRecord(String topic, String key, String value) {
         return new StoredProducerRecord(

--- a/kafka/src/test/java/no/nav/common/kafka/producer/feilhandtering/KafkaProducerRepositoryTest.java
+++ b/kafka/src/test/java/no/nav/common/kafka/producer/feilhandtering/KafkaProducerRepositoryTest.java
@@ -1,6 +1,8 @@
 package no.nav.common.kafka.producer.feilhandtering;
 
 import no.nav.common.kafka.producer.util.ProducerUtils;
+import no.nav.common.kafka.spring.OracleJdbcTemplateProducerRepository;
+import no.nav.common.kafka.spring.PostgresJdbcTemplateProducerRepository;
 import no.nav.common.kafka.utils.DbUtils;
 import no.nav.common.kafka.utils.LocalOracleH2Database;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -36,11 +38,11 @@ public class KafkaProducerRepositoryTest {
         DataSource postgres = createPostgresDataSource(postgreSQLContainer);
 
         DbUtils.runScript(postgres, "kafka-producer-record-postgres.sql");
-        PostgresProducerRepository postgresProducerRepository = new PostgresProducerRepository(new JdbcTemplate(postgres));
+        PostgresJdbcTemplateProducerRepository postgresProducerRepository = new PostgresJdbcTemplateProducerRepository(new JdbcTemplate(postgres));
 
         DataSource oracle = LocalOracleH2Database.createDatabase();
         DbUtils.runScript(oracle, "kafka-producer-record-oracle.sql");
-        OracleProducerRepository oracleProducerRepository = new OracleProducerRepository(new JdbcTemplate(oracle));
+        OracleJdbcTemplateProducerRepository oracleProducerRepository = new OracleJdbcTemplateProducerRepository(new JdbcTemplate(oracle));
 
         return Arrays.asList(
                 new Object[]{"POSTGRES", postgres, postgresProducerRepository},

--- a/kafka/src/test/java/no/nav/common/kafka/producer/feilhandtering/KafkaProducerRepositoryTest.java
+++ b/kafka/src/test/java/no/nav/common/kafka/producer/feilhandtering/KafkaProducerRepositoryTest.java
@@ -11,6 +11,7 @@ import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import javax.sql.DataSource;
@@ -35,11 +36,11 @@ public class KafkaProducerRepositoryTest {
         DataSource postgres = createPostgresDataSource(postgreSQLContainer);
 
         DbUtils.runScript(postgres, "kafka-producer-record-postgres.sql");
-        PostgresProducerRepository postgresProducerRepository = new PostgresProducerRepository(postgres);
+        PostgresProducerRepository postgresProducerRepository = new PostgresProducerRepository(new JdbcTemplate(postgres));
 
         DataSource oracle = LocalOracleH2Database.createDatabase();
         DbUtils.runScript(oracle, "kafka-producer-record-oracle.sql");
-        OracleProducerRepository oracleProducerRepository = new OracleProducerRepository(oracle);
+        OracleProducerRepository oracleProducerRepository = new OracleProducerRepository(new JdbcTemplate(oracle));
 
         return Arrays.asList(
                 new Object[]{"POSTGRES", postgres, postgresProducerRepository},


### PR DESCRIPTION
Måten connections til databasen ble hentet på tok ikke høyde for transaksjoner ved bruk av Spring. Endrer derfor implementasjonen til å være konkret rettet mot å bruke Spring. Andre implementasjoner kan implementeres ved behov.