### PR TITLE
Endret log innslag fra error til info

### DIFF
--- a/client/src/main/java/no/nav/common/client/nom/NomClientImpl.java
+++ b/client/src/main/java/no/nav/common/client/nom/NomClientImpl.java
@@ -117,7 +117,7 @@ public class NomClientImpl implements NomClient {
             RessursQuery.ResponseData.RessurserItem.Ressurs ressurs = ressursItem.ressurs;
 
             if (ressurs == null || ressurs.visningsNavn == null || ressurs.fornavn == null || ressurs.etternavn == null ) {
-                log.info("Fant ikke navn til veileder med ident: {}", ressursItem.id);
+                log.warn("Fant ikke navn til veileder med ident: {}", ressursItem.id);
                 return;
             }
 

--- a/client/src/main/java/no/nav/common/client/nom/NomClientImpl.java
+++ b/client/src/main/java/no/nav/common/client/nom/NomClientImpl.java
@@ -117,7 +117,7 @@ public class NomClientImpl implements NomClient {
             RessursQuery.ResponseData.RessurserItem.Ressurs ressurs = ressursItem.ressurs;
 
             if (ressurs == null || ressurs.visningsNavn == null || ressurs.fornavn == null || ressurs.etternavn == null ) {
-                log.error("Fant ikke navn til veileder med ident: {}", ressursItem.id);
+                log.info("Fant ikke navn til veileder med ident: {}", ressursItem.id);
                 return;
             }
 


### PR DESCRIPTION
På grunn av situasjonen i Axsys, der det ikke er ryddet opp i utgåtte identer, vill dette logges ofte uten at det egentlig er en error. Dette er i alle fall tilfellet til veilarbveileder. 