### PR TITLE
Seek back on failed messages in Kafka consumer

### DIFF
--- a/kafka/src/main/java/no/nav/common/kafka/consumer/KafkaConsumerClientImpl.java
+++ b/kafka/src/main/java/no/nav/common/kafka/consumer/KafkaConsumerClientImpl.java
@@ -212,12 +212,9 @@ public class KafkaConsumerClientImpl<K, V> implements KafkaConsumerClient, Consu
                     log.error("Failed to commit offsets: " + offsetsToCommit, e);
                 }
 
-                try {
-                    seekBackOnFailed();
-                } catch (Exception e) {
-                    // If we fail to seek back then continue polling records
-                    log.error("Failed to seek back", e);
-                }
+                // We do not catch exceptions if seeking back fails since we then will lose messages.
+                // Propagates exception so the consumer restarts.
+                seekBackOnFailed();
             }
         } catch (Exception e) {
             log.error("Unexpected exception caught from main loop. Shutting down...", e);


### PR DESCRIPTION
Messages will be lost if not seeking back since the next poll will continue polling newer messages, disregarding which offset that has been commited.