### PR TITLE
Legger til anonymisert navn for veileder som ikke har navn i nom

### DIFF
--- a/client/src/main/java/no/nav/common/client/nom/NomClientImpl.java
+++ b/client/src/main/java/no/nav/common/client/nom/NomClientImpl.java
@@ -66,7 +66,11 @@ public class NomClientImpl implements NomClient {
         List<VeilederNavn> veilederNavn = finnNavn(Collections.singletonList(navIdent));
 
         if (veilederNavn.isEmpty()) {
-            throw new IllegalStateException("Fant ikke navn for NAV-ident: " + navIdent);
+            // Vi kan her anta at personen er skjult?
+            return new VeilederNavn().setNavIdent(navIdent)
+                    .setFornavn("Anonym")
+                    .setEtternavn(navIdent.get())
+                    .setVisningsNavn("Anonym " + navIdent.get());
         }
 
         return veilederNavn.get(0);


### PR DESCRIPTION
Jeg vet egentlig ikke hvordan denne situasjonen skal løses, men jeg lager en draft for å kunne starte diskusjonen.

Problemet er at veiledere fra vikafossen ikke har navn i NOM/AzureAD