### PR TITLE
Improve shedlock

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -44,7 +44,7 @@
         <commons-io.version>2.7</commons-io.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4</httpcore.version>
-        <shedlock.version>4.21.0</shedlock.version>
+        <shedlock.version>4.30.0</shedlock.version>
         <handlebars.version>4.1.2</handlebars.version>
         <kafka.version>2.8.0</kafka.version>
         <avro.version>1.9.2</avro.version>

--- a/job/src/main/java/no/nav/common/job/leader_election/ShedLockLeaderElectionClient.java
+++ b/job/src/main/java/no/nav/common/job/leader_election/ShedLockLeaderElectionClient.java
@@ -26,7 +26,7 @@ public class ShedLockLeaderElectionClient implements LeaderElectionClient {
 
     private final static Duration LOCK_AT_LEAST_FOR = Duration.ofSeconds(10);
 
-    private final static long CHECK_LOCK_EVERY_SECONDS = 60;
+    private final static long CHECK_LOCK_INTERVAL_IN_SECONDS = 60;
 
     // The clock skew is strictly speaking not necessary since we only compare timestamps that has been made by this class.
     // We still add a tiny skew to prevent problems from happening when checking a lock that is just about to expire.
@@ -51,7 +51,7 @@ public class ShedLockLeaderElectionClient implements LeaderElectionClient {
         scheduler = Executors.newSingleThreadScheduledExecutor();
         hostname = EnvironmentUtils.resolveHostName();
 
-        scheduler.scheduleWithFixedDelay(this::keepLockAlive, 0, CHECK_LOCK_EVERY_SECONDS, TimeUnit.SECONDS);
+        scheduler.scheduleWithFixedDelay(this::keepLockAlive, 0, CHECK_LOCK_INTERVAL_IN_SECONDS, TimeUnit.SECONDS);
         Runtime.getRuntime().addShutdownHook(new Thread(this::shutdownHook));
     }
 
@@ -85,7 +85,7 @@ public class ShedLockLeaderElectionClient implements LeaderElectionClient {
                     log.warn("Unable to extend lock");
                 }
             } catch (UnsupportedOperationException uoe) {
-                log.error("Shed lock leader election is being used with a lock provider that does not support lock extension", uoe);
+                log.error("ShedLock leader election is being used with a lock provider that does not support lock extension", uoe);
             } catch (Exception e) {
                 log.error("Caught exception when extending leader election lock", e);
             }
@@ -118,7 +118,7 @@ public class ShedLockLeaderElectionClient implements LeaderElectionClient {
     }
 
     private void shutdownHook() {
-        log.info("Shutting down shedlock leader election client...");
+        log.info("Shutting down ShedLock leader election client...");
 
         hasShutDown = true;
         scheduler.shutdown();

--- a/job/src/test/java/no/nav/common/job/leader_election/ShedLockLeaderElectionClientTest.java
+++ b/job/src/test/java/no/nav/common/job/leader_election/ShedLockLeaderElectionClientTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.*;
 public class ShedLockLeaderElectionClientTest {
 
     @Test
-    public void should_acquire_lock_for_one_client_and_deny_the_other() {
+    public void should_acquire_lock_for_one_client_and_deny_the_other() throws InterruptedException {
        AtomicInteger counter = new AtomicInteger();
 
         LockProvider provider = lockConfiguration -> {
@@ -23,7 +23,10 @@ public class ShedLockLeaderElectionClientTest {
         };
 
         ShedLockLeaderElectionClient client1 = new ShedLockLeaderElectionClient(provider);
+        Thread.sleep(100); // Ensures that client1 is always the leader
+
         ShedLockLeaderElectionClient client2 = new ShedLockLeaderElectionClient(provider);
+        Thread.sleep(100); // Ensures that client2 has tried to check the lock once
 
         assertTrue(client1.isLeader());
         assertFalse(client2.isLeader());
@@ -31,7 +34,7 @@ public class ShedLockLeaderElectionClientTest {
         assertTrue(client1.isLeader());
         assertFalse(client2.isLeader());
 
-        assertEquals(3, counter.get()); // Client 1 should only increment once
+        assertEquals(2, counter.get()); // Clients should only increment once
     }
 
 }


### PR DESCRIPTION
Istedenfor at brukere av ShedLockLeaderElectionClient må sørge for å polle jevnlig for at samme pod skal bli leder, så er det bedre hvis ShedLockLeaderElectionClient gjør dette selv.

Dette fikser problemer hvor man f.eks har veldig lange jobber og man ikke får pollet leader election klienten nok slik at en annen instanse blir leder mens den forrige lederen utfører den lange jobben.