### PR TITLE
Bruk concurrent maps for kafka metrikker

### DIFF
--- a/kafka/src/main/java/no/nav/common/kafka/consumer/util/TopicConsumerMetrics.java
+++ b/kafka/src/main/java/no/nav/common/kafka/consumer/util/TopicConsumerMetrics.java
@@ -6,8 +6,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import no.nav.common.kafka.consumer.ConsumeStatus;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Consumer listener which adds a consumption status metric for each topic + partition
@@ -22,11 +22,11 @@ public class TopicConsumerMetrics<K, V> implements TopicConsumerListener<K, V> {
 
     private final MeterRegistry meterRegistry;
 
-    private final Map<String, Counter> statusCounterMap = new HashMap<>();
+    private final Map<String, Counter> statusCounterMap = new ConcurrentHashMap<>();
 
-    private final Map<String, Gauge> consumedOffsetGaugeMap = new HashMap<>();
+    private final Map<String, Gauge> consumedOffsetGaugeMap = new ConcurrentHashMap<>();
 
-    private final Map<String, Long> consumedOffsetMap = new HashMap<>();
+    private final Map<String, Long> consumedOffsetMap = new ConcurrentHashMap<>();
 
     public TopicConsumerMetrics(MeterRegistry meterRegistry) {
         this.meterRegistry = meterRegistry;

--- a/kafka/src/main/java/no/nav/common/kafka/producer/util/KafkaProducerClientWithMetrics.java
+++ b/kafka/src/main/java/no/nav/common/kafka/producer/util/KafkaProducerClientWithMetrics.java
@@ -10,9 +10,9 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 
 public class KafkaProducerClientWithMetrics<K, V> implements KafkaProducerClient<K, V> {
@@ -25,11 +25,11 @@ public class KafkaProducerClientWithMetrics<K, V> implements KafkaProducerClient
 
     private final MeterRegistry meterRegistry;
 
-    private final Map<String, Counter> statusCounterMap = new HashMap<>();
+    private final Map<String, Counter> statusCounterMap = new ConcurrentHashMap<>();
 
-    private final Map<String, Gauge> currentOffsetGaugeMap = new HashMap<>();
+    private final Map<String, Gauge> currentOffsetGaugeMap = new ConcurrentHashMap<>();
 
-    private final Map<String, Long> currentOffsetMap = new HashMap<>();
+    private final Map<String, Long> currentOffsetMap = new ConcurrentHashMap<>();
 
     public KafkaProducerClientWithMetrics(Properties properties, MeterRegistry meterRegistry) {
         this.client = new KafkaProducerClientImpl<>(properties);


### PR DESCRIPTION
Hvis man oppdaterer vanlig HashMap så vil det bli kastet et exception når man endrer det samtidig fra forskjellige tråder.