### PR TITLE
Gjør regex test på call-id mer robust

### DIFF
--- a/rest/src/test/java/no/nav/common/rest/client/RestClientTest.java
+++ b/rest/src/test/java/no/nav/common/rest/client/RestClientTest.java
@@ -79,7 +79,7 @@ public class RestClientTest {
 
         givenThat(get(anyUrl()).willReturn(aResponse().withStatus(200)));
 
-        var idPattern = matching("^[a-z0-9]{32}$");
+        var idPattern = matching("^[a-z0-9]{30}(\\w*)$");
 
         try (Response ignored = client.newCall(request).execute()) {
             verify(getRequestedFor(anyUrl())


### PR DESCRIPTION
Noen ganger så er det 31-tegn istedenfor 32-tegn, håndter begge tilfeller