### PR TITLE
Pin versjonen av commons-collections for å fikse potensielt sikkerhetshull

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -74,6 +74,16 @@
 
     <dependencyManagement>
         <dependencies>
+            <!--
+                Dette er en midlertidig patch, i nyere versjoner av f.eks org.apache.cxf:cxf-rt-ws-security
+                så trengs forhåpentligvis ikke dette.
+            -->
+            <dependency>
+                <groupId>commons-collections</groupId>
+                <artifactId>commons-collections</artifactId>
+                <version>3.2.2</version>
+            </dependency>
+
             <!-- START COMMON -->
             <dependency>
                 <groupId>no.nav.common</groupId>


### PR DESCRIPTION
org.apache.cxf:cxf-rt-ws-security trekker inn en transitiv avhengighet med en kritisk sårbarhet. Versjon 3.2.2 er allerede i bruk siden den blir trukket inn fra en annen avhengighet, men det er litt skummelt å ha det som eneste sikkerhetslinje