### PR TITLE
Gjør cookie domain/path konfigurerbart

### DIFF
--- a/auth/src/main/java/no/nav/common/auth/oidc/filter/OidcAuthenticationFilter.java
+++ b/auth/src/main/java/no/nav/common/auth/oidc/filter/OidcAuthenticationFilter.java
@@ -102,8 +102,8 @@ public class OidcAuthenticationFilter implements Filter {
     private void addNewIdTokenCookie(
             OidcAuthenticatorConfig oidcConfig, JWT jwtToken, HttpServletRequest request, HttpServletResponse response
     ) throws ParseException {
-        String cookieDomain = oidcConfig.cookieDomain != null ? oidcConfig.cookieDomain : cookieDomain(request);
-        String cookiePath = oidcConfig.cookiePath != null ? oidcConfig.cookiePath : "/";
+        String cookieDomain = oidcConfig.refreshedCookieDomain != null ? oidcConfig.refreshedCookieDomain : cookieDomain(request);
+        String cookiePath = oidcConfig.refreshedCookiePath != null ? oidcConfig.refreshedCookiePath : "/";
         Date cookieExpiration = jwtToken.getJWTClaimsSet().getExpirationTime();
 
         Cookie newIdCookie = CookieUtils.createCookie(

--- a/auth/src/main/java/no/nav/common/auth/oidc/filter/OidcAuthenticator.java
+++ b/auth/src/main/java/no/nav/common/auth/oidc/filter/OidcAuthenticator.java
@@ -4,9 +4,7 @@ import lombok.Value;
 import no.nav.common.auth.oidc.OidcTokenValidator;
 import no.nav.common.auth.utils.CookieUtils;
 
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -34,14 +32,9 @@ public class OidcAuthenticator {
                 .collect(Collectors.toList());
     }
 
-    public Optional<Cookie> findIdTokenCookie(HttpServletRequest request) {
-        return Optional.ofNullable(config.idTokenCookieName)
-                .flatMap(tokenName -> CookieUtils.getCookie(tokenName, request));
-    }
-
     public Optional<String> findIdToken(HttpServletRequest request) {
-        Optional<String> maybeIdTokenFromCookie = findIdTokenCookie(request)
-                .map(Cookie::getValue);
+        Optional<String> maybeIdTokenFromCookie = Optional.ofNullable(config.idTokenCookieName)
+                .flatMap(tokenName -> CookieUtils.getCookieValue(tokenName, request));
 
         if (maybeIdTokenFromCookie.isPresent()) {
             return maybeIdTokenFromCookie;

--- a/auth/src/main/java/no/nav/common/auth/oidc/filter/OidcAuthenticatorConfig.java
+++ b/auth/src/main/java/no/nav/common/auth/oidc/filter/OidcAuthenticatorConfig.java
@@ -38,11 +38,11 @@ public class OidcAuthenticatorConfig {
     // Url to call when refreshing the id token (optional)
     public String refreshUrl;
 
-    // Domain for id token cookie (optional)
-    public String cookieDomain;
+    // Domain to use for the refreshed id token cookie (optional)
+    public String refreshedCookieDomain;
 
-    // Path for id token cookie (optional)
-    public String cookiePath;
+    // Path to use for the refreshed id token cookie (optional)
+    public String refreshedCookiePath;
 
     public boolean isValid() {
         return discoveryUrl != null

--- a/auth/src/main/java/no/nav/common/auth/oidc/filter/OidcAuthenticatorConfig.java
+++ b/auth/src/main/java/no/nav/common/auth/oidc/filter/OidcAuthenticatorConfig.java
@@ -38,6 +38,12 @@ public class OidcAuthenticatorConfig {
     // Url to call when refreshing the id token (optional)
     public String refreshUrl;
 
+    // Domain for id token cookie (optional)
+    public String cookieDomain;
+
+    // Path for id token cookie (optional)
+    public String cookiePath;
+
     public boolean isValid() {
         return discoveryUrl != null
                 && clientIds != null

--- a/auth/src/test/java/no/nav/common/auth/oidc/filter/OidcAuthenticationFilterTest.java
+++ b/auth/src/test/java/no/nav/common/auth/oidc/filter/OidcAuthenticationFilterTest.java
@@ -88,8 +88,8 @@ public class OidcAuthenticationFilterTest {
                 .withRefreshUrl(azureAdOidcProviderRule.getRefreshUri())
                 .withIdTokenCookieName(AZURE_AD_ID_TOKEN_COOKIE_NAME)
                 .withRefreshTokenCookieName(REFRESH_TOKEN_COOKIE_NAME)
-                .withCookieDomain("overridden.local")
-                .withCookiePath("/overriddenpath");
+                .withRefreshedCookieDomain("overridden.local")
+                .withRefreshedCookiePath("/overriddenpath");
 
         openAMAuthenticatorConfig = new OidcAuthenticatorConfig()
                 .withDiscoveryUrl(openAMOidcProviderRule.getDiscoveryUri())

--- a/auth/src/test/java/no/nav/common/auth/oidc/filter/OidcAuthenticationFilterTest.java
+++ b/auth/src/test/java/no/nav/common/auth/oidc/filter/OidcAuthenticationFilterTest.java
@@ -62,6 +62,8 @@ public class OidcAuthenticationFilterTest {
 
     private OidcAuthenticatorConfig azureAdAuthenticatorConfig;
 
+    private OidcAuthenticatorConfig azureAdAuthenticatorConfigCookieOverride;
+
     private OidcAuthenticatorConfig openAMAuthenticatorConfig;
 
     @Before
@@ -78,6 +80,16 @@ public class OidcAuthenticationFilterTest {
                 .withRefreshUrl(azureAdOidcProviderRule.getRefreshUri())
                 .withIdTokenCookieName(AZURE_AD_ID_TOKEN_COOKIE_NAME)
                 .withRefreshTokenCookieName(REFRESH_TOKEN_COOKIE_NAME);
+
+        azureAdAuthenticatorConfigCookieOverride = new OidcAuthenticatorConfig()
+                .withDiscoveryUrl(azureAdOidcProviderRule.getDiscoveryUri())
+                .withClientId(azureAdOidcProviderRule.getAudience())
+                .withUserRole(UserRole.INTERN)
+                .withRefreshUrl(azureAdOidcProviderRule.getRefreshUri())
+                .withIdTokenCookieName(AZURE_AD_ID_TOKEN_COOKIE_NAME)
+                .withRefreshTokenCookieName(REFRESH_TOKEN_COOKIE_NAME)
+                .withCookieDomain("overridden.local")
+                .withCookiePath("/overriddenpath");
 
         openAMAuthenticatorConfig = new OidcAuthenticatorConfig()
                 .withDiscoveryUrl(openAMOidcProviderRule.getDiscoveryUri())
@@ -351,7 +363,7 @@ public class OidcAuthenticationFilterTest {
     @Test
     public void shouldRefreshWithCorrectCookieDomainAndPath() throws IOException, ServletException {
         OidcAuthenticationFilter authenticationFilter = new OidcAuthenticationFilter(
-                singletonList(OidcAuthenticator.fromConfig(azureAdAuthenticatorConfig))
+                singletonList(OidcAuthenticator.fromConfig(azureAdAuthenticatorConfigCookieOverride))
         );
 
         JwtTestTokenIssuer.Claims claims = new JwtTestTokenIssuer.Claims("me");
@@ -365,7 +377,7 @@ public class OidcAuthenticationFilterTest {
 
         when(servletRequest.getServerName()).thenReturn("test.local");
         when(servletRequest.getCookies()).thenReturn(new Cookie[]{
-                CookieUtils.createCookie(azureAdAuthenticatorConfig.idTokenCookieName, token, "overridden.local", "/overriddenpath", 0, false),
+                CookieUtils.createCookie(azureAdAuthenticatorConfigCookieOverride.idTokenCookieName, token, "overridden.local", "/overriddenpath", 0, false),
                 CookieUtils.createCookie(REFRESH_TOKEN_COOKIE_NAME, "my-refresh-token", "overridden.local", "/overriddenpath", 0, false)
         });
 


### PR DESCRIPTION
Revertering av endringene i #581 og legger til muligheten for å konfigurere domain/path.

Gjøres fordi browseren ikke sender med domain/path i `Cookie` headeren, så man kan ikke kopiere disse derifra.
