### PR TITLE
Forbedret caching av OBO-tokens

### DIFF
--- a/token-client/src/main/java/no/nav/common/token_client/client/AzureAdOnBehalfOfTokenClient.java
+++ b/token-client/src/main/java/no/nav/common/token_client/client/AzureAdOnBehalfOfTokenClient.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 import static java.util.Optional.ofNullable;
 import static no.nav.common.token_client.utils.TokenClientUtils.*;
-import static no.nav.common.token_client.utils.TokenUtils.hashToken;
+import static no.nav.common.token_client.utils.TokenUtils.getSubject;
 
 @Slf4j
 public class AzureAdOnBehalfOfTokenClient extends AbstractTokenClient implements OnBehalfOfTokenClient {
@@ -24,7 +24,7 @@ public class AzureAdOnBehalfOfTokenClient extends AbstractTokenClient implements
 
     @Override
     public String exchangeOnBehalfOfToken(String tokenScope, String accessToken) {
-        String cacheKey = tokenScope + "-" + hashToken(accessToken);
+        String cacheKey = tokenScope + "-" + getSubject(accessToken);
 
         return ofNullable(tokenCache)
                 .map(cache -> cache.getFromCacheOrTryProvider(cacheKey, () -> exchangeToken(tokenScope, accessToken)))

--- a/token-client/src/main/java/no/nav/common/token_client/client/TokenXOnBehalfOfTokenClient.java
+++ b/token-client/src/main/java/no/nav/common/token_client/client/TokenXOnBehalfOfTokenClient.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 import static java.util.Optional.ofNullable;
 import static no.nav.common.token_client.utils.TokenClientUtils.*;
-import static no.nav.common.token_client.utils.TokenUtils.hashToken;
+import static no.nav.common.token_client.utils.TokenUtils.getSubject;
 
 @Slf4j
 public class TokenXOnBehalfOfTokenClient extends AbstractTokenClient implements OnBehalfOfTokenClient {
@@ -26,7 +26,7 @@ public class TokenXOnBehalfOfTokenClient extends AbstractTokenClient implements 
 
     @Override
     public String exchangeOnBehalfOfToken(String tokenScope, String accessToken) {
-        String cacheKey = tokenScope + "-" + hashToken(accessToken);
+        String cacheKey = tokenScope + "-" + getSubject(accessToken);
 
         return ofNullable(tokenCache)
                 .map(cache -> cache.getFromCacheOrTryProvider(cacheKey, () -> exchangeToken(tokenScope, accessToken)))

--- a/token-client/src/main/java/no/nav/common/token_client/utils/TokenUtils.java
+++ b/token-client/src/main/java/no/nav/common/token_client/utils/TokenUtils.java
@@ -4,10 +4,7 @@ import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTParser;
 import lombok.SneakyThrows;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.text.ParseException;
-import java.util.Base64;
 import java.util.Date;
 
 public class TokenUtils {
@@ -44,11 +41,20 @@ public class TokenUtils {
         }
     }
 
-    @SneakyThrows
-    public static String hashToken(String token) {
-        MessageDigest digest = MessageDigest.getInstance("SHA-256");
-        byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
-        return Base64.getEncoder().encodeToString(hash);
+    public static String getSubject(String accessToken) {
+        try {
+            JWT token = JWTParser.parse(accessToken);
+
+            String subject = token.getJWTClaimsSet().getSubject();
+
+            if (subject == null) {
+                throw new IllegalArgumentException("Unable to get subject, access token is missing subject");
+            }
+
+            return subject;
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("Unable to get subject, access token is invalid");
+        }
     }
 
 }

--- a/token-client/src/test/java/no/nav/common/token_client/cache/CaffeineTokenCacheTest.java
+++ b/token-client/src/test/java/no/nav/common/token_client/cache/CaffeineTokenCacheTest.java
@@ -18,7 +18,7 @@ public class CaffeineTokenCacheTest {
 
         Supplier<String> supplier = () -> {
             counter.incrementAndGet();
-            return TokenCreator.instance().createToken();
+            return TokenCreator.instance().createToken("test");
         };
 
         tokenCache.getFromCacheOrTryProvider("key1", supplier);
@@ -35,7 +35,7 @@ public class CaffeineTokenCacheTest {
 
         Supplier<String> supplier = () -> {
             counter.incrementAndGet();
-            return TokenCreator.instance().createToken();
+            return TokenCreator.instance().createToken("test");
         };
 
         tokenCache.getFromCacheOrTryProvider("key1", supplier);

--- a/token-client/src/test/java/no/nav/common/token_client/client/AzureAdMachineToMachineTokenClientTest.java
+++ b/token-client/src/test/java/no/nav/common/token_client/client/AzureAdMachineToMachineTokenClientTest.java
@@ -34,7 +34,7 @@ public class AzureAdMachineToMachineTokenClientTest {
 
     @Test
     public void skal_lage_riktig_request_og_parse_response() throws InterruptedException {
-        String accessToken = TokenCreator.instance().createToken();
+        String accessToken = TokenCreator.instance().createToken("test");
 
         server.enqueue(tokenMockResponse(accessToken));
 
@@ -63,9 +63,8 @@ public class AzureAdMachineToMachineTokenClientTest {
 
     @Test
     public void should_cache_request() {
-        server.enqueue(tokenMockResponse(TokenCreator.instance().createToken()));
-        server.enqueue(tokenMockResponse(TokenCreator.instance().createToken()));
-        server.enqueue(tokenMockResponse(TokenCreator.instance().createToken()));
+        server.enqueue(tokenMockResponse(TokenCreator.instance().createToken("test-1")));
+        server.enqueue(tokenMockResponse(TokenCreator.instance().createToken("test-2")));
 
         AzureAdMachineToMachineTokenClient tokenClient = new AzureAdMachineToMachineTokenClient(
                 "test-id",

--- a/token-client/src/test/java/no/nav/common/token_client/client/AzureAdOnBehalfOfTokenClientTest.java
+++ b/token-client/src/test/java/no/nav/common/token_client/client/AzureAdOnBehalfOfTokenClientTest.java
@@ -14,8 +14,7 @@ import java.util.Map;
 import static no.nav.common.token_client.test_utils.Constants.TEST_JWK;
 import static no.nav.common.token_client.test_utils.RequestUtils.parseFormData;
 import static no.nav.common.token_client.test_utils.RequestUtils.tokenMockResponse;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AzureAdOnBehalfOfTokenClientTest {
 
@@ -34,7 +33,7 @@ public class AzureAdOnBehalfOfTokenClientTest {
 
     @Test
     public void skal_lage_riktig_request_og_parse_response() throws InterruptedException {
-        String accessToken = TokenCreator.instance().createToken();
+        String accessToken = TokenCreator.instance().createToken("test");
 
         server.enqueue(tokenMockResponse(accessToken));
 
@@ -45,7 +44,7 @@ public class AzureAdOnBehalfOfTokenClientTest {
                 new CaffeineTokenCache()
         );
 
-        String token = tokenClient.exchangeOnBehalfOfToken("test-scope", TokenCreator.instance().createToken());
+        String token = tokenClient.exchangeOnBehalfOfToken("test-scope", TokenCreator.instance().createToken("test"));
 
         RecordedRequest recordedRequest = server.takeRequest();
 
@@ -63,9 +62,9 @@ public class AzureAdOnBehalfOfTokenClientTest {
 
     @Test
     public void should_cache_request() {
-        server.enqueue(tokenMockResponse(TokenCreator.instance().createToken()));
-        server.enqueue(tokenMockResponse(TokenCreator.instance().createToken()));
-        server.enqueue(tokenMockResponse(TokenCreator.instance().createToken()));
+        server.enqueue(tokenMockResponse(TokenCreator.instance().createToken("user-1")));
+        server.enqueue(tokenMockResponse(TokenCreator.instance().createToken("user-2")));
+        server.enqueue(tokenMockResponse(TokenCreator.instance().createToken("user-2")));
 
         AzureAdOnBehalfOfTokenClient tokenClient = new AzureAdOnBehalfOfTokenClient(
                 "test-id",
@@ -74,11 +73,13 @@ public class AzureAdOnBehalfOfTokenClientTest {
                 new CaffeineTokenCache()
         );
 
-        String token1 = TokenCreator.instance().createToken();
-        String token2 = TokenCreator.instance().createToken();
+        String token1 = TokenCreator.instance().createToken("user-1");
+        String token2 = TokenCreator.instance().createToken("user-2");
+        String token3 = TokenCreator.instance().createToken("user-1");
 
         tokenClient.exchangeOnBehalfOfToken("test-scope", token1);
         tokenClient.exchangeOnBehalfOfToken("test-scope", token1);
+        tokenClient.exchangeOnBehalfOfToken("test-scope", token3);
 
         assertEquals(1, server.getRequestCount());
 
@@ -86,6 +87,22 @@ public class AzureAdOnBehalfOfTokenClientTest {
         tokenClient.exchangeOnBehalfOfToken("test-scope-2", token2);
 
         assertEquals(3, server.getRequestCount());
+    }
+
+    @Test
+    public void should_throw_exception_if_subject_missing() {
+        AzureAdOnBehalfOfTokenClient tokenClient = new AzureAdOnBehalfOfTokenClient(
+                "test-id",
+                server.url("/token").toString(),
+                TEST_JWK,
+                new CaffeineTokenCache()
+        );
+
+        String token = TokenCreator.instance().createToken(null);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            tokenClient.exchangeOnBehalfOfToken("test-scope", token);
+        }, "Unable to get subject, access token is missing subject");
     }
 
 }

--- a/token-client/src/test/java/no/nav/common/token_client/test_utils/TokenCreator.java
+++ b/token-client/src/test/java/no/nav/common/token_client/test_utils/TokenCreator.java
@@ -31,14 +31,14 @@ public class TokenCreator {
     }
 
     @SneakyThrows
-    public String createToken() {
-        return createToken(60 * 1000);
+    public String createToken(String subject) {
+        return createToken(subject, 60 * 1000);
     }
 
     @SneakyThrows
-    public String createToken(int expireFromNowMs) {
+    public String createToken(String subject, int expireFromNowMs) {
         JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
-                .subject("test")
+                .subject(subject)
                 .issuer("https://example.com")
                 .jwtID(UUID.randomUUID().toString())
                 .expirationTime(new Date(new Date().getTime() + expireFromNowMs))


### PR DESCRIPTION
Istedenfor å bruke hash av tokenet som cache key, så bruker vi heller subject claimet i tokenet.
Dette vil gjøre at appen vil gjøre langt færre exchanges hvis den mottar forskjellige OBO-token med samme subject (bruker).