### PR TITLE
AzureAd mot pdl skal ikke ha med Nav-Consumer-Token

### DIFF
--- a/client/src/main/java/no/nav/common/client/aktoroppslag/PdlAktorOppslagClient.java
+++ b/client/src/main/java/no/nav/common/client/aktoroppslag/PdlAktorOppslagClient.java
@@ -48,6 +48,10 @@ public class PdlAktorOppslagClient implements AktorOppslagClient {
         this.pdlClient = new PdlClientImpl(pdlUrl, Tema.GEN, userTokenSupplier, consumerTokenSupplier);
     }
 
+    public PdlAktorOppslagClient(String pdlUrl, Supplier<String> azureAdTokenSupplier) {
+        this.pdlClient = new PdlClientImpl(pdlUrl, Tema.GEN, azureAdTokenSupplier, null);
+    }
+
     public PdlAktorOppslagClient(PdlClient pdlClient) {
         this.pdlClient = pdlClient;
     }


### PR DESCRIPTION
Tenker at en ny konstruktør kan gjøre det lettere å gå over til bruk av AzureAd mot pdl