### PR TITLE
upgrade kafka and kafka-avro-serializer

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -53,9 +53,9 @@
         <jetty.version>9.4.44.v20210927</jetty.version>
 
         <!-- KAFKA -->
-        <kafka.version>3.3.1</kafka.version>
+        <kafka.version>7.3.0-ccs</kafka.version>
         <avro.version>1.11.1</avro.version>
-        <avro-serializer.version>6.1.1</avro-serializer.version>
+        <avro-serializer.version>7.3.0</avro-serializer.version>
         <json-schema-validation.version>1.12.2</json-schema-validation.version>
 
         <!-- TEST -->


### PR DESCRIPTION
@AlexGaard 
Hadde problemer med at `kafka-avro-serializer` dro med seg `org.apache.kafka:kafka-clients:6.1.1-ccs` som dermed ble valgt i stedet for `org.apache.kafka:kafka-clients:3.1.1`. 

Basert på svar i https://stackoverflow.com/questions/61532385/kafka-dependencies-ccs-vs-ce så ser det ut som at confluent sine 7.x.x-pakker tilsvarer 3.x.x av Apache Kafka.
Ved å sette `kafka-avro-serializer` til `7.3.0` så går avhengighetene hos oss opp igjen, men jeg registrerer likevel en slags "mismatch" med at `kafka-avro-serializer` har en avhengighet til `7.3.0-ccs` av `kafka-clients`, så jeg satt denne versjonen eksplisitt til conlfluent sine releases også.

Kan være det er en bedre løsning på kabalen, f.eks. kun oppgradere `<avro-serializer.verion>` (hvis det er slik at vi har gjort et bevisst valg med å bruke Apache Kafka releases i stedet for Confluent sine), eller å trekke denne serializer-modulen ut til en egen pakke. 