### PR TITLE
Endre fra jakarta- til javaximport i javaxversjon

### DIFF
--- a/rest/src/main/java/no/nav/common/rest/filter/JavaxSetHeaderFilter.java
+++ b/rest/src/main/java/no/nav/common/rest/filter/JavaxSetHeaderFilter.java
@@ -1,8 +1,8 @@
 package no.nav.common.rest.filter;
 
-import jakarta.servlet.*;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.util.Map;


### PR DESCRIPTION
Må ha javax i javaxversjon av filen frem til man er klar til å gå over til jakarta (finnes også en jakartaversjon: https://github.com/navikt/common-java-modules/blob/main/rest/src/main/java/no/nav/common/rest/filter/SetHeaderFilter.java)

For mer info, se https://github.com/navikt/common-java-modules/pull/666/files