### PR TITLE
nedgraderer plugin pga kjent bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -727,7 +727,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.2.1</version>
                     <executions>
                         <execution>
                             <goals>


### PR DESCRIPTION
Nedgraderer mvn-source-plugin fordi versjon 3.3.x har en kjent bug som vi treffer ved release av common-java-modules: https://issues.apache.org/jira/browse/MSOURCES-143