### PR TITLE
rydd opp rundt tester i log-modulen

### DIFF
--- a/log/src/test/java/no/nav/common/log/LogTestHelpers.java
+++ b/log/src/test/java/no/nav/common/log/LogTestHelpers.java
@@ -1,0 +1,34 @@
+package no.nav.common.log;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.joran.spi.JoranException;
+import ch.qos.logback.core.util.StatusPrinter2;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+
+import static java.util.Objects.requireNonNull;
+
+public class LogTestHelpers {
+    public static void loadLogbackConfig(String path) throws JoranException {
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        loggerContext.reset();
+
+        URL configUrl = LogTestHelpers.class.getResource(path);
+        requireNonNull(configUrl, "Config file not found: " + path);
+
+        JoranConfigurator configurator = new JoranConfigurator();
+        configurator.setContext(loggerContext);
+        configurator.doConfigure(configUrl);
+
+        var statusPrinter = new StatusPrinter2();
+        statusPrinter.printInCaseOfErrorsOrWarnings(loggerContext);
+    }
+
+    public static void flushLogs() {
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        loggerContext.stop();
+        loggerContext.start();
+    }
+}

--- a/log/src/test/java/no/nav/common/log/LogbackSecureLogsTest.java
+++ b/log/src/test/java/no/nav/common/log/LogbackSecureLogsTest.java
@@ -1,9 +1,5 @@
 package no.nav.common.log;
 
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.joran.JoranConfigurator;
-import ch.qos.logback.core.joran.spi.JoranException;
-import ch.qos.logback.core.util.StatusPrinter;
 import com.google.gson.Gson;
 import lombok.SneakyThrows;
 import org.junit.Rule;
@@ -13,7 +9,6 @@ import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -37,43 +32,21 @@ public class LogbackSecureLogsTest {
     @Test
     @SneakyThrows
     public void skal_logge_json_til_securelogs() {
-
-        loadLogbackConfig("/logback-securelogs-test.xml");
+        LogTestHelpers.loadLogbackConfig("/logback-securelogs-test.xml");
 
         Logger secureLogs = LoggerFactory.getLogger("SecureLog");
 
         secureLogs.info(HEMMELIG_MELDING);
 
+        LogTestHelpers.flushLogs();
 
-        flushLogs();
         String logMessages = new String(Files.readAllBytes(Paths.get(SECURELOGS_DIR + "/secure.log")));
 
         Gson gson = new Gson();
-        Optional<LogLinje> lastSecurelogMessage = Arrays.stream(logMessages
-                .split("\n"))
+        Optional<LogLinje> lastSecurelogMessage = Arrays.stream(logMessages.split("\n"))
                 .map(l -> gson.fromJson(l, LogLinje.class))
                 .reduce((logLinje, logLinje2) -> logLinje2);
 
-
-
         assertThat(lastSecurelogMessage.get().message).isEqualTo(HEMMELIG_MELDING);
-    }
-
-
-
-    private void loadLogbackConfig(String path) throws JoranException {
-        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-        loggerContext.reset();
-        // Sett konfigurasjonsfilen for LoggerContext
-
-        URL configUrl = getClass().getResource(path);
-        JoranConfigurator configurator = new JoranConfigurator();
-        configurator.setContext(loggerContext);configurator.doConfigure(configUrl);
-        StatusPrinter.printInCaseOfErrorsOrWarnings(loggerContext);
-    }
-
-    private static void flushLogs() {
-        LoggerContext loggerContext1 = (LoggerContext) LoggerFactory.getILoggerFactory();
-        loggerContext1.stop();
     }
 }

--- a/log/src/test/java/no/nav/common/log/LogbackStdoutJsonTest.java
+++ b/log/src/test/java/no/nav/common/log/LogbackStdoutJsonTest.java
@@ -1,21 +1,17 @@
 package no.nav.common.log;
 
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.joran.JoranConfigurator;
-import ch.qos.logback.core.joran.spi.JoranException;
-import ch.qos.logback.core.util.StatusPrinter2;
 import com.google.gson.Gson;
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.List;
 import lombok.SneakyThrows;
 import org.codehaus.commons.nullanalysis.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.List;
 
 
 public class LogbackStdoutJsonTest {
@@ -25,7 +21,7 @@ public class LogbackStdoutJsonTest {
     public void fodselsnummerSkalMaskerer() {
         PrintStream out = System.out;
 
-        LoadLogbackConfig("/logback-test.xml");
+        LogTestHelpers.loadLogbackConfig("/logback-test.xml");
         ByteArrayOutputStream outputStream = captureSystemOut();
 
         Logger log = LoggerFactory.getLogger(LogbackStdoutJsonTest.class);
@@ -37,12 +33,12 @@ public class LogbackStdoutJsonTest {
         String skalIkkeMaskeres = "denne skal ikke maskerers 123456789123456789 eller kanskje den blir det?";
         log.info(skalIkkeMaskeres);
 
-        flushLogs();
+        LogTestHelpers.flushLogs();
 
         String logtext = outputStream.toString();
 
         //da andre ting også logger når vi kjører testen må vi fjerne alle lingjer som ikke er json
-        var logLinjes = hentLingjerSomStarterMedCurlyBraces(logtext);
+        var logLinjes = hentLinjerSomStarterMedCurlyBraces(logtext);
 
         Assert.assertEquals("skal bare vere 2 log lingjer", 2, logLinjes.size());
 
@@ -61,7 +57,7 @@ public class LogbackStdoutJsonTest {
     public void skal_logge_json_med_logbackStdoutJson() {
         PrintStream out = System.out;
 
-        LoadLogbackConfig("/logback-test.xml");
+        LogTestHelpers.loadLogbackConfig("/logback-test.xml");
         ByteArrayOutputStream outputStream = captureSystemOut();
 
         Logger log = LoggerFactory.getLogger(LogbackStdoutJsonTest.class);
@@ -74,12 +70,12 @@ public class LogbackStdoutJsonTest {
         String errorMelding = "Feilmelding";
         log.error(errorMelding);
 
-        flushLogs();
+        LogTestHelpers.flushLogs();
 
         String logtext = outputStream.toString();
 
         //da andre ting også logger når vi kjører testen må vi fjerne alle lingjer som ikke er json
-        var logLinjes = hentLingjerSomStarterMedCurlyBraces(logtext);
+        var logLinjes = hentLinjerSomStarterMedCurlyBraces(logtext);
 
         Assert.assertEquals("skal være 3 loglingjer (ikke debug)", 3, logLinjes.size());
 
@@ -110,7 +106,7 @@ public class LogbackStdoutJsonTest {
         System.setOut(out);
     }
 
-    private static List<LogLinje> hentLingjerSomStarterMedCurlyBraces(String logtext) {
+    private static List<LogLinje> hentLinjerSomStarterMedCurlyBraces(String logtext) {
         Gson gson = new Gson();
         return Arrays.stream(logtext.split("\n"))
                 .filter(l -> l.startsWith("{"))
@@ -118,33 +114,10 @@ public class LogbackStdoutJsonTest {
                 .toList();
     }
 
-
-    private void LoadLogbackConfig(String path) throws JoranException {
-        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-        loggerContext.reset();
-        loggerContext.putProperty("testName", "LogbackTest");
-        loggerContext.putProperty("logDirectory", "logs");
-        // Sett konfigurasjonsfilen for LoggerContext
-
-        URL configUrl = getClass().getResource(path);
-        JoranConfigurator configurator = new JoranConfigurator();
-        configurator.setContext(loggerContext);
-        configurator.doConfigure(configUrl);
-
-        var statusPrinter = new StatusPrinter2();
-        statusPrinter.printInCaseOfErrorsOrWarnings(loggerContext);
-    }
-
     @NotNull
     private static ByteArrayOutputStream captureSystemOut() {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         System.setOut(new PrintStream(outputStream));
         return outputStream;
-    }
-
-    private static void flushLogs() {
-        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-        loggerContext.stop();
-        loggerContext.start();
     }
 }


### PR DESCRIPTION
testene oppleves som flaky, men ved å trekke ut "flushLogs" og samtidig sørge for å starte loggerContext'en etter at den stoppes så kjører i hvert fall disse testene lokalt