### PR TITLE
benytt riktig key ved opprettelse av guage

### DIFF
--- a/kafka/src/main/java/no/nav/common/kafka/consumer/util/TopicConsumerMetrics.java
+++ b/kafka/src/main/java/no/nav/common/kafka/consumer/util/TopicConsumerMetrics.java
@@ -49,7 +49,7 @@ public class TopicConsumerMetrics<K, V> implements TopicConsumerListener<K, V> {
 
             consumedOffsetMap.put(offsetMapKey, record.offset());
 
-            consumedOffsetGaugeMap.computeIfAbsent(statusMapKey, (k) ->
+            consumedOffsetGaugeMap.computeIfAbsent(offsetMapKey, (k) ->
                     Gauge.builder(KAFKA_CONSUMER_CONSUMED_OFFSET_GAUGE, () -> {
                         Long offset = consumedOffsetMap.get(offsetMapKey);
                         return offset != null ? offset : 0;


### PR DESCRIPTION
For å fikse warning-log om `This Gauge has been already registered (MeterId{name='kafka_consumer_consumed_offset', tags=[tag(partition=<partition>),tag(topic=<topic>)]}), the registration will be ignored.`