### PR TITLE
Fikser bug i MaskingAppender slik at MDC blir logget

### DIFF
--- a/log/src/main/java/no/nav/common/log/MaskingAppender.java
+++ b/log/src/main/java/no/nav/common/log/MaskingAppender.java
@@ -10,4 +10,8 @@ public class MaskingAppender extends AsyncAppenderBase<ILoggingEvent> {
         super.append(new MaskedLoggingEvent(iLoggingEvent));
     }
 
+    @Override
+    protected void preprocess(ILoggingEvent eventObject) {
+        eventObject.prepareForDeferredProcessing();
+    }
 }

--- a/log/src/test/java/no/nav/common/log/LogbackStdoutJsonTest.java
+++ b/log/src/test/java/no/nav/common/log/LogbackStdoutJsonTest.java
@@ -7,11 +7,13 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 
 public class LogbackStdoutJsonTest {
@@ -47,6 +49,33 @@ public class LogbackStdoutJsonTest {
 
         LogLinje skalIkkeBliMaskert = logLinjes.get(1);
         Assert.assertEquals(skalIkkeMaskeres, skalIkkeBliMaskert.message);
+
+        System.setOut(out);
+    }
+
+    @Test
+    @SneakyThrows
+    public void loglinjeSkalInkludereMDCFelter() {
+        PrintStream out = System.out;
+
+        LogTestHelpers.loadLogbackConfig("/logback-test.xml");
+        ByteArrayOutputStream outputStream = captureSystemOut();
+
+        Logger log = LoggerFactory.getLogger(LogbackStdoutJsonTest.class);
+
+        String mdcKey = UUID.randomUUID().toString();
+        MDC.put(mdcKey, "value");
+        log.info("en random logglinje");
+        MDC.remove(mdcKey);
+
+        LogTestHelpers.flushLogs();
+
+        String logtext = outputStream.toString();
+
+        // da andre ting også logger når vi kjører testen må vi fjerne alle lingjer som ikke er json
+        var logLinjes = hentLinjerSomStarterMedCurlyBraces(logtext);
+        Assert.assertEquals("skal bare vere 1 log lingjer", 1, logLinjes.size());
+        Assert.assertTrue(logtext.contains(mdcKey));
 
         System.setOut(out);
     }


### PR DESCRIPTION
Kaller prepareForDeferredProcessing før logghendelser legges på async-køen, slik at MDC-kontekst kopieres fra opprinnelig tråd. Dette gjør at MDC-felter igjen blir med i logglinjene etter oppgradering av Logback.

Feilen ble introdusert ved oppgradering av logback fra versjon 1.4.14 til 1.5.16 tilbake i Januar 2025. Så det var tilsynelatende en liten endring i logback og hvordan MDC-kontekst ble håndtert i AsyncAppender-flyten mellom disse minor-versjonene. 