### PR TITLE
oppgraderer avhengigheter

### DIFF
--- a/log/src/main/resources/no/nav/common/log/logback-cxf.xml
+++ b/log/src/main/resources/no/nav/common/log/logback-cxf.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <included>
-    <if condition='isDefined("CXF_SECURE_LOG")'>
+    <condition class="ch.qos.logback.core.boolex.IsPropertyDefinedCondition">
+        <key>CXF_SECURE_LOG</key>
+    </condition>
+    <if>
         <then>
             <logger name="org.apache.cxf" level="${CXF_SECURE_LOG_LEVEL:-INFO}">
                 <appender-ref ref="secureLog"/>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
         <!-- LOGGING -->
         <slf4j.version>2.0.18</slf4j.version>
-        <logback.version>1.5.34</logback.version>
+        <logback.version>1.5.37</logback.version>
         <logback-syslog4j.version>1.0.0</logback-syslog4j.version>
         <janino.version>3.1.12</janino.version>
         <logstash-logback.version>9.0</logstash-logback.version>
@@ -95,7 +95,7 @@
         <commons-lang.version>3.20.0</commons-lang.version>
         <commons-io.version>2.22.0</commons-io.version>
         <shedlock.version>7.7.0</shedlock.version>
-        <handlebars.version>4.5.2</handlebars.version>
+        <handlebars.version>4.5.3</handlebars.version>
         <gson.version>2.14.0</gson.version>
         <caffeine.version>3.2.4</caffeine.version>
         <bitbucket-jose4.version>0.9.6</bitbucket-jose4.version>
@@ -113,11 +113,11 @@
         <assertj.version>3.27.7</assertj.version>
         <hamcrest.version>3.0</hamcrest.version>
         <mockito.version>5.23.0</mockito.version>
-        <junit.jupiter.version>6.1.0</junit.jupiter.version>
+        <junit.jupiter.version>6.1.1</junit.jupiter.version>
         <wiremock.version>3.13.2</wiremock.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <h2.version>2.4.240</h2.version>
-        <postgres.version>42.7.11</postgres.version>
+        <postgres.version>42.7.12</postgres.version>
         <bytebuddy.version>1.18.10</bytebuddy.version><!-- overstyrer utdatert versjon fra mockito -->
     </properties>
 


### PR DESCRIPTION
isDefined er ikke lenger støttet i nye versjoner av logback. 